### PR TITLE
Fix: Error message when changing purchase log status via AJAX.

### DIFF
--- a/wpsc-admin/ajax.php
+++ b/wpsc-admin/ajax.php
@@ -385,10 +385,15 @@ function _wpsc_ajax_change_purchase_log_status() {
 	if ( ! $result )
 		return new WP_Error( 'wpsc_cannot_edit_purchase_log_status', __( "Couldn't modify purchase log's status. Please try again.", 'wpsc' ) );
 
-	set_current_screen( 'dashboard_page_wpsc-sales-logs' );
+	$args = array();
+
+	if ( version_compare( get_bloginfo( 'version' ), '3.5', '<' ) )
+		set_current_screen( 'dashboard_page_wpsc-sales-logs' );
+	else
+		$args['screen'] = 'dashboard_page_wpsc-sales-logs';
 
 	require_once( WPSC_FILE_PATH . '/wpsc-admin/includes/purchase-log-list-table-class.php' );
-	$purchaselog_table = new WPSC_Purchase_Log_List_Table();
+	$purchaselog_table = new WPSC_Purchase_Log_List_Table( $args );
 	$purchaselog_table->prepare_items();
 
 	ob_start();

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -19,10 +19,9 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table
 	private $where;
 	private $where_no_filter;
 
-	public function __construct() {
-		WP_List_Table::__construct( array(
-			'plural' => 'purchase-logs',
-		) );
+	public function __construct( $args = array() ) {
+		$args['plural'] = 'purchase-logs';
+		parent::__construct( $args );
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX )
 			$_SERVER['REQUEST_URI'] = wp_get_referer();


### PR DESCRIPTION
Since WordPress 3.5, WP_List_Table no longer relies on globals to
detect current screen, but rely on the 'screen' arg which is passed
to the constructor.

See: https://github.com/WordPress/WordPress/commit/a3cfe285278c4fe7668ba35310341880d7cced65
for more details.

An audit still needs to be done in 3.8.10, but at least we can move #31
to 3.8.10 now.
