### PR TITLE
Variation table class orderby to 'menu_order title'

### DIFF
--- a/wpsc-admin/includes/product-variation-list-table.class.php
+++ b/wpsc-admin/includes/product-variation-list-table.class.php
@@ -38,7 +38,6 @@ class WPSC_Product_Variation_List_Table extends WP_List_Table
 
 		$per_page = $this->get_items_per_page( 'edit_wpsc-product-variations_per_page' );
 		$per_page = apply_filters( 'edit_wpsc_product_variations_per_page', $per_page );
-		//changed orderby to 'menu_order title' because post_title isn't a proper orderby clause for WP_Query
 		$this->args = array(
 			'post_type'      => 'wpsc-product',
 			'orderby'        => 'menu_order title',


### PR DESCRIPTION
Changed orderby to 'menu_order title' because post_title isn't a proper orderby clause for WP_Query
