### PR TITLE
Fix for Issue 84 - Google Analytics output not respecting $display_to_screen

### DIFF
--- a/wpsc-includes/google-analytics.class.php
+++ b/wpsc-includes/google-analytics.class.php
@@ -25,7 +25,7 @@ class WPSC_Google_Analytics {
 			|| ( ! $this->is_theme_tracking && empty( $this->tracking_id ) );
 
 		if ( ! $this->is_analytics_disabled )
-			add_action( 'wpsc_transaction_results_shutdown', array( $this, 'print_script' ), 10, 2 );
+			add_action( 'wpsc_transaction_results_shutdown', array( $this, 'print_script' ), 10, 3 );
 	}
 
 	/**
@@ -48,10 +48,17 @@ class WPSC_Google_Analytics {
 	 * If analytics are disabled, we build nothing.
 	 * If the site already is tracking OR using the advanced option, we insert only the e-commerce portion, not the initial tracking info.
 	 *
+	 * @param $purchase_log      Purchase Log object
+	 * @param $session_id        Session ID
+	 * @param $display_to_screen Whether or not the output is displayed to the screen
+	 * 
 	 * @since 3.8.9
 	 * @return javascript
 	 */
-	public function print_script( $object, $session_id ) {
+	public function print_script( $purchase_log, $session_id, $display_to_screen ) {
+
+		if ( ! $display_to_screen )
+			return false;
 
 		$output = '';
 


### PR DESCRIPTION
We weren't making use of the $display_to_screen variable here when we should have been.  It was causing issues where transaction_results() would be called on order status changes, triggering this output when it was inappropriate.
