### PR TITLE
Passing the post_id through wpsc_the_product_title

### DIFF
--- a/wpsc-includes/product-template.php
+++ b/wpsc-includes/product-template.php
@@ -712,8 +712,8 @@ function wpsc_edit_the_product_link( $link = null, $before = '', $after = '', $i
  * wpsc the product title function
  * @return string - the product title
  */
-function wpsc_the_product_title() {
-	return get_the_title();
+function wpsc_the_product_title( $post = 0 ) {
+	return get_the_title( $post );
 }
 
 /**


### PR DESCRIPTION
Seems silly that WordPress allows a post_id in get_the_title and when
WPEC provides it's own function it doesn' allow the parameter. In
general we should be passing the params that WordPress expects unless
it's retarded.
