### PR TITLE
Return cart item messages as key => value array rather than HTML.

### DIFF
--- a/wpsc-admin/display-sales-logs.php
+++ b/wpsc-admin/display-sales-logs.php
@@ -178,7 +178,7 @@ class WPSC_Purchase_Log_Page
                      <h4><?php esc_html_e( 'Cart Items with Custom Messages' , 'wpsc' ); ?>:</h4>
                      <?php
                      foreach($messages as $message){
-                        echo esc_html( $message );
+                        echo esc_html( $message['title'] ) . ':<br />' . nl2br( esc_html( $message['message'] ) );
                      }
                   } ?>
                </div>

--- a/wpsc-includes/purchaselogs.class.php
+++ b/wpsc-includes/purchaselogs.class.php
@@ -107,7 +107,10 @@ function wpsc_purchlogs_custommessages() {
    $messages = array();
    foreach ( $purchlogitem->allcartcontent as $cartitem ) {
 	  if ( $cartitem->custom_message != '' ) {
-		 $messages[] = apply_filters( 'the_title', $cartitem->name ) . ' :<br />' . $cartitem->custom_message;
+		 $messages[] = array(
+		 	'title'   => apply_filters( 'the_title', $cartitem->name ),
+		 	'message' => $cartitem->custom_message,
+		 );
 	  }
    }
    return $messages;


### PR DESCRIPTION
In the admin when viewing a purchase log item with personalisation, if the customer has entered line break into the field, these are not displayed.

Also, as $messages contains an HTML line break that is later escaped using esc_html() in purchase_log_custom_fields() which outputs the HTML as text.

I did a search of the codebase and wpsc_purchlogs_custommessages() is only used here. My feeling is this should return an array of data rather than HTML - keep everything as data for as long as possible and format it just before output.

This commit alters wpsc_purchlogs_custommessages() to return an array, and formats the output of purchase_log_custom_fields() with line breaks.
