### PR TITLE
Remove 'legacy' action for wpsc_meta_boxes

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -412,9 +412,8 @@ function wpsc_meta_boxes() {
 		add_meta_box( 'wpsc_product_shipping_forms', __('Shipping', 'wpsc'), 'wpsc_product_shipping_forms_metabox', $pagename, 'normal', 'high' );
 	add_meta_box( 'wpsc_product_advanced_forms', __('Advanced Settings', 'wpsc'), 'wpsc_product_advanced_forms', $pagename, 'normal', 'high' );
 }
-
-add_action( 'admin_footer', 'wpsc_meta_boxes' );
 add_action( 'admin_enqueue_scripts', 'wpsc_admin_include_css_and_js_refac' );
+
 function wpsc_admin_include_css_and_js_refac( $pagehook ) {
 	global $post_type, $current_screen, $post;
 


### PR DESCRIPTION
Looking through the code in wpsc-admin/admin.php I see we have a call to `add_action( 'admin_footer', 'wpsc_meta_boxes' );`. The custom meta boxes are already being set via a callback in wpsc-core/wpsc-functions.php.

Is this call around for some legacy reason that is no longer needed?

Metaboxes should really be called on the callback (as it is) or on add_meta_boxes.
