### PR TITLE
adding wpsc_purchlogitem_metabox_end hook to item-details.php

### DIFF
--- a/wpsc-admin/includes/purchase-logs-page/item-details.php
+++ b/wpsc-admin/includes/purchase-logs-page/item-details.php
@@ -132,6 +132,7 @@
 			<!-- End Order Notes (by Ben) -->
 
 			<?php $this->purchase_logs_checkout_fields(); ?>
+			<?php do_action( 'wpsc_purchlogitem_metabox_end', $this->log_id ); ?>
 
 		</div>
 	</div>


### PR DESCRIPTION
We're trying to stop non-link items from getting hooked to wpsc_purchlogitem_links_start by providing a specific spot to hook non-link meta.

See Github issue
https://github.com/wp-e-commerce/WP-e-Commerce/issues/122

Basically just making a proper spot for developers to hook in to when
they want to add non-link metaboxes.
