### PR TITLE
Re-generate products pages' IDs after plugin reactivation.

### DIFF
--- a/wpsc-core/wpsc-functions.php
+++ b/wpsc-core/wpsc-functions.php
@@ -1816,3 +1816,44 @@ function wpsc_delete_all_customer_meta( $id = false ) {
 	else
 		return delete_transient( "wpsc_customer_meta_{$blog_prefix}{$id}" );
 }
+
+/**
+ * Updates permalink slugs
+ *
+ * @since 3.8.9
+ * @return type
+ */
+function wpsc_update_permalink_slugs() {
+	global $wpdb;
+
+	$wpsc_pageurl_option = array(
+		'product_list_url'  => '[productspage]',
+		'shopping_cart_url' => '[shoppingcart]',
+		'checkout_url'      => '[shoppingcart]',
+		'transact_url'      => '[transactionresults]',
+		'user_account_url'  => '[userlog]'
+	);
+
+	$ids = array();
+
+	foreach ( $wpsc_pageurl_option as $option_key => $page_string ) {
+		$id = $wpdb->get_var( "SELECT `ID` FROM `{$wpdb->posts}` WHERE `post_type` = 'page' AND `post_content` LIKE '%$page_string%' LIMIT 1" );
+
+		if ( ! $id )
+			continue;
+
+		$ids[$page_string] = $id;
+
+		$the_new_link = get_page_link( $id );
+
+		if ( stristr( get_option( $option_key ), "https://" ) )
+			$the_new_link = str_replace( 'http://', "https://", $the_new_link );
+
+		if ( $option_key == 'shopping_cart_url' )
+			update_option( 'checkout_url', $the_new_link );
+
+		update_option( $option_key, $the_new_link );
+	}
+
+	update_option( 'wpsc_shortcode_page_ids', $ids );
+}

--- a/wpsc-core/wpsc-installer.php
+++ b/wpsc-core/wpsc-installer.php
@@ -268,6 +268,8 @@ You ordered these items:
 	//unset products page
 	unset($pages['products-page']);
 
+	require_once( WPSC_FILE_PATH . '/wpsc-core/wpsc-functions.php' );
+
 	//create other pages
 	foreach( (array)$pages as $page ){
 		//check if page exists and get it's ID
@@ -298,11 +300,10 @@ You ordered these items:
 	//if we have created any new pages, then flush... do we need to do this? probably should be removed
 	if ( $newpages ) {
 		wp_cache_delete( 'all_page_ids', 'pages' );
-		$wp_rewrite->flush_rules();
+		wpsc_update_permalink_slugs();
 	}
 	// Product categories, temporarily register them to create first default category if none exist
 	// @todo: investigate those require once lines and move them to right place (not from here, but from their original location, which seems to be wrong, since i cant access wpsc_register_post_types and wpsc_update_categorymeta here) - Vales <v.bakaitis@gmail.com>
-	require_once( WPSC_FILE_PATH . '/wpsc-core/wpsc-functions.php' );
 	wpsc_core_load_page_titles();
 	wpsc_register_post_types();
 	$category_list = get_terms( 'wpsc_product_category', 'hide_empty=0&parent=0' );
@@ -314,7 +315,6 @@ You ordered these items:
 		$term = get_term_by( 'id', $new_category['term_id'], 'wpsc_product_category' );
 		$url_name = $term->slug;
 
-		$wp_rewrite->flush_rules();
 		wpsc_update_categorymeta( $category_id, 'nice-name', $url_name );
 		wpsc_update_categorymeta( $category_id, 'description', __( "This is a description", 'wpsc' ) );
 		wpsc_update_categorymeta( $category_id, 'image', '' );

--- a/wpsc-includes/display.functions.php
+++ b/wpsc-includes/display.functions.php
@@ -264,47 +264,6 @@ function wpsc_refresh_page_urls( $post_id, $post ) {
 add_action( 'save_post', 'wpsc_refresh_page_urls', 10, 2 );
 
 /**
- * Updates permalink slugs
- *
- * @since 3.8.9
- * @return type
- */
-function wpsc_update_permalink_slugs() {
-	global $wpdb;
-
-	$wpsc_pageurl_option = array(
-		'product_list_url'  => '[productspage]',
-		'shopping_cart_url' => '[shoppingcart]',
-		'checkout_url'      => '[shoppingcart]',
-		'transact_url'      => '[transactionresults]',
-		'user_account_url'  => '[userlog]'
-	);
-
-	$ids = array();
-
-	foreach ( $wpsc_pageurl_option as $option_key => $page_string ) {
-		$id = $wpdb->get_var( "SELECT `ID` FROM `{$wpdb->posts}` WHERE `post_type` = 'page' AND `post_content` LIKE '%$page_string%' LIMIT 1" );
-
-		if ( ! $id )
-			continue;
-
-		$ids[$page_string] = $id;
-
-		$the_new_link = get_page_link( $id );
-
-		if ( stristr( get_option( $option_key ), "https://" ) )
-			$the_new_link = str_replace( 'http://', "https://", $the_new_link );
-
-		if ( $option_key == 'shopping_cart_url' )
-			update_option( 'checkout_url', $the_new_link );
-
-		update_option( $option_key, $the_new_link );
-	}
-
-	update_option( 'wpsc_shortcode_page_ids', $ids );
-}
-
-/**
  * wpsc_obtain_the_title function, for replaacing the page title with the category or product
  * @return string - the new page title
  */


### PR DESCRIPTION
Issue #132.
