### PR TITLE
Removed legacy add_contextual_help function

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -298,15 +298,12 @@ function wpsc_add_help_tabs() {
 		}
 		$content .= '<p>' . implode( '<br />', $links ) . '</p>';
 
-		if ( version_compare( get_bloginfo( 'version' ), '3.3', '<' ) ) {
-			add_contextual_help( $screen->id, $content );
-		} else {
-			$screen->add_help_tab( array(
-				'id'      => $screen->id . '_help',
-				'title'   => $tab['title'],
-				'content' => $content,
-			) );
-		}
+		$screen->add_help_tab( array(
+			'id'      => $screen->id . '_help',
+			'title'   => $tab['title'],
+			'content' => $content,
+		) );
+
 	}
 }
 


### PR DESCRIPTION
WPEC is dropping support for 3.3 so we can drop the usage of this
function.

See issue https://github.com/wp-e-commerce/WP-e-Commerce/issues/116
