### PR TITLE
Fixed variable error in wpsc-shipping/usps_20.php

### DIFF
--- a/wpsc-shipping/usps_20.php
+++ b/wpsc-shipping/usps_20.php
@@ -913,7 +913,7 @@ class ash_usps{
             $wpec_ash = new ASH();
         }
 	    if (!is_object($wpec_ash_tools)){
-            $wpec_ash = new ASHTools();
+            $wpec_ash_tools = new ASHTools();
         }
 
 	    $this->shipment = $wpec_ash->get_shipment();


### PR DESCRIPTION
The variable being tested is NOT the one being assigned the new instance of ASHTools().
