### PR TITLE
removing usages of $wpdb where declared but never used

### DIFF
--- a/wpsc-admin/ajax.php
+++ b/wpsc-admin/ajax.php
@@ -427,7 +427,6 @@ function _wpsc_ajax_change_purchase_log_status() {
  * @return array|WP_Error Response args if successful, WP_Error if otherwise
  */
 function _wpsc_ajax_save_product_order() {
-	global $wpdb;
 
 	$products = array( );
 	foreach ( $_POST['post'] as $product ) {

--- a/wpsc-admin/display-debug.page.php
+++ b/wpsc-admin/display-debug.page.php
@@ -12,7 +12,7 @@
 function wpsc_debug_page() {
 	if ( !current_user_can('manage_options') )
 		wp_die("You don't look like an administrator.");
-	global $wpdb;
+
 	$fixpage = admin_url( 'admin.php?page=wpsc-sales-logs&amp;subpage=upgrade-purchase-logs' );
 ?>
 	<div class="wrap">


### PR DESCRIPTION
Fixes for #144 and #155.

Just removes usages of `$wpdb` where it was declared but never used in the function. I don't see a reason for it to be there.
