### PR TITLE
Encode image links

### DIFF
--- a/wpsc-includes/productfeed.php
+++ b/wpsc-includes/productfeed.php
@@ -99,7 +99,7 @@ function wpsc_generate_product_feed() {
 			if ($image_link !== FALSE) {
 
 				if ($_GET['xmlformat'] == 'google') {
-					echo "      <g:image_link>$image_link</g:image_link>\n\r";
+					echo "      <g:image_link><![CDATA[$image_link]]></g:image_link>\n\r";
 				} else {
 					echo "      <enclosure url='$image_link' />\n\r";
 				}


### PR DESCRIPTION
Image links of the format http://wpec38/index.php?wpsc_action=scale_image&attachment_id=29&width=148&height=148 aren't correctly escaped in the Google Product feed. See:

http://getshopped.org/forums/topic/google-merchant-feed-does-not-work-2/#post-300953

Pull request attached.
