### PR TITLE
Add filters to allow the sales log list page to be extended

### DIFF
--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -132,7 +132,7 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		$orderby = empty( $_REQUEST['orderby'] ) ? 'p.id' : 'p.' . $_REQUEST['orderby'];
 		$order = empty( $_REQUEST['order'] ) ? 'DESC' : $_REQUEST['order'];
 
-		$orderby = esc_sql( $orderby );
+		$orderby = esc_sql( apply_filters( 'wpsc_manage_purchase_logs_orderby', $orderby ) );
 		$order = esc_sql( $order );
 
 		$submitted_data_log = WPSC_TABLE_SUBMITED_FORM_DATA;
@@ -144,7 +144,8 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 			ORDER BY {$orderby} {$order}
 			{$limit}
 		";
-		$this->items = $wpdb->get_results( $purchase_log_sql );
+
+		$this->items = apply_filters( 'wpsc_manage_purchase_logs_items', $wpdb->get_results( $purchase_log_sql ) );
 		if ( $this->per_page ) {
 			$total_items = $wpdb->get_var( "SELECT FOUND_ROWS()" );
 


### PR DESCRIPTION
This solves the questions raised in https://github.com/wp-e-commerce/WP-e-Commerce/issues/11

The first commit adds the basic changes required to register the column, and have information displayed. The second is to do with "sortable". It adds two filters so that either:
- The SQL orderby clause can be filtered
  or
- The items returned by the query can be filtered

I'm not sure how useful the latter filter would be based on pagination>
