### PR TITLE
Bug - archive tag title

### DIFF
--- a/wpsc-includes/theme.functions.php
+++ b/wpsc-includes/theme.functions.php
@@ -453,8 +453,6 @@ function _wpsc_is_in_custom_loop() {
  */
 function wpsc_the_category_title( $title='', $id='' ){
 
-	global $wp_query;
-
 	if ( ! empty( $id ) )
 		_wpsc_deprecated_argument( __FUNCTION__, '3.8.10', 'The $id param is not used. If you are trying to get the title of the category use get_term' );
 


### PR DESCRIPTION
Issue Reference: https://github.com/wp-e-commerce/WP-e-Commerce/issues/166

The bug was because we were calling `product-tag` in get_term_by instead of `product_tag`. I assume (maybe incorrectly) that product tags were registered with a dash at one point and then when WordPress made that not work, this was missed in the conversion to underscore.

Or maybe it was always _ and this just was typed as a dash by accident.

I also took the time to fix up the formatting to align it with WordPress standards and put a proper doc block in.

Few questions:
1. The function allows for $id, but never uses it. Can it just be pulled from the function?
2. The conditional (the huge one) in the function is really huge. Is it used anywhere else? Could we abstract it to a conditional statement that just returns a boolean value?

I just noted that I incorrectly removed a global for `$wpdb`. I'll fix that up in a new commit shortly.
