### PR TITLE
Just a simple fix to avoid a PHP warning

### DIFF
--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -456,7 +456,7 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 
 	public function column_status( $item ) {
 		global $wpsc_purchlog_statuses;
-		$dropdown_options = array();
+		$dropdown_options = '';
 		$current_status = false;
 		foreach ( $wpsc_purchlog_statuses as $status ) {
 			$selected = '';


### PR DESCRIPTION
$dropdown_options was initialised as array(), but should be a string as it's concatenated, and output a few lines later. 
