### PR TITLE
Filter gateway checkout form output

### DIFF
--- a/wpsc-components/merchant-core-v2/helpers/gateways.php
+++ b/wpsc-components/merchant-core-v2/helpers/gateways.php
@@ -4,17 +4,28 @@
  * The WPSC Gateway functions
  */
 
+/**
+ * @TODO Needs desription adding, and return value clarifying.
+ * @return bool [description]
+ */
 function wpsc_have_gateways() {
 	global $wpsc_gateway;
 	return $wpsc_gateway->have_gateways();
 }
 
+/**
+ * @TODO Needs desription adding, and return value clarifying.
+ * @return [type] [description]
+ */
 function wpsc_the_gateway() {
 	global $wpsc_gateway;
 	return $wpsc_gateway->the_gateway();
 }
 
-//return true only when gateway has image set
+/**
+ * Indicate if the current gateway has an image provided.
+ * @return bool True if the gateway has an image, false if not.
+ */
 function wpsc_show_gateway_image(){
 	global $wpsc_gateway;
 	if( isset($wpsc_gateway->gateway['image']) && !empty($wpsc_gateway->gateway['image']) )
@@ -23,8 +34,10 @@ function wpsc_show_gateway_image(){
 		return false;
 }
 
-
-//return gateway image url (string) or false if none.
+/**
+ * Return the current gateway's image url if there is one.
+ * @return string|bool Returns the URL of the gateway image, or false if none set.
+ */
 function wpsc_gateway_image_url(){
 	global $wpsc_gateway;
 	if( wpsc_show_gateway_image() )
@@ -33,6 +46,10 @@ function wpsc_gateway_image_url(){
 		return false;
 }
 
+/**
+ * Return the current gateway's name.
+ * @return string The current gateway's name.
+ */
 function wpsc_gateway_name() {
 	global $wpsc_gateway;
 	$display_name = '';
@@ -69,11 +86,20 @@ function wpsc_gateway_name() {
 	return $display_name;
 }
 
+
+/**
+ * Return the current gateway's internal name
+ * @return string The current gateway's internal name.
+ */
 function wpsc_gateway_internal_name() {
 	global $wpsc_gateway;
 	return $wpsc_gateway->gateway['internalname'];
 }
 
+/**
+ * Return HTML to check a radio button if the current gateway is the currently selected gateway.
+ * @return string HTML checked attribute if the current gateway is selectedd. Empty string otherwise.
+ */
 function wpsc_gateway_is_checked() {
 	global $wpsc_gateway;
 	$is_checked = false;
@@ -96,6 +122,11 @@ function wpsc_gateway_is_checked() {
 	return $output;
 }
 
+/**
+ * Return the HTML output for the current gateway's checkout fields.
+ * @return string The HTML of the current gateway's checkout fields.
+ * @uses apply_filters() Filters output through wpsc_gateway_checkout_form_{gateway_internal_name}
+ */
 function wpsc_gateway_form_fields() {
 	global $wpsc_gateway, $gateway_checkout_form_fields, $wpsc_gateway_error_messages;
 
@@ -152,6 +183,11 @@ function wpsc_gateway_form_fields() {
 
 }
 
+/**
+ * Return HTML class to be added to a checkout field to indicate if thi field belongs to the
+ * currently selected gateway.
+ * @return string HTML class
+ */
 function wpsc_gateway_form_field_style() {
 	global $wpsc_gateway;
 	$is_checked = false;
@@ -178,6 +214,9 @@ add_action(
 	'_wpsc_merchant_v2_before_shopping_cart'
 );
 
+/**
+ * @TODO Clarify what this is doing
+ */
 function _wpsc_merchant_v2_before_shopping_cart() {
 	$GLOBALS['wpsc_gateway'] = new wpsc_gateways();
 }


### PR DESCRIPTION
Gateway checkout form fields are normally generated by the gateway early on in the WordPress load cycle. From my testing it looks like this happens too early for things like the wpsc_cart object to have been loaded.

If a gateway needs to insert information into the form based on information about the cart there doesn't seem to be a clean way to do so. This filter makes the checkout form output be passed through a filter at the point it's rendered so that gateways can add additional information. 

It worksforme(TM) but could probably use a bit of sanity checking as I haven't had chance to test it comprehensively across all gateways.
