### PR TITLE
Pull Request - Remove 'Delete' sale link from Sales Log page - Issue #182

### DIFF
--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -421,7 +421,7 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 	public function column_id( $item ) {
 		?>
 		<a href="<?php echo esc_url( $this->item_url( $item ) ); ?>" title="<?php esc_attr_e( 'View order details', 'wpsc' ) ?>"><?php echo esc_html( $item->id ); ?></a>
-		<?php if ( ! $this->current_action() == 'delete' ): ?>
+		<?php if ( ! $this->current_action() == 'delete' && current_user_can('level_10')): ?>
 			<br />
 			<small><a class="delete" href="<?php echo esc_url( $this->delete_url( $item ) ); ?>"><?php echo esc_html_x( 'Delete', 'Sales log page', 'wpsc' ); ?></a></small>
 		<?php endif ?>


### PR DESCRIPTION
Pull request for Issue #182
Once an e-Commerce site is live, you really don't want to be deleting Sales records. There are legal requirements in most countries to maintain sales records for auditing.
This will disable /hide the 'Delete' button from the sales log page unless the current user is an Admin (Level_10). This allows deletion when developing a site, or under exceptional circumstances for example.
