### PR TITLE
Remove name="submit" from checkout page submit buttons

### DIFF
--- a/wpsc-theme/wpsc-shopping_cart_page.php
+++ b/wpsc-theme/wpsc-shopping_cart_page.php
@@ -64,7 +64,7 @@ endif;
                <input type="text" name="quantity" size="2" value="<?php echo wpsc_cart_item_quantity(); ?>" />
                <input type="hidden" name="key" value="<?php echo wpsc_the_cart_item_key(); ?>" />
                <input type="hidden" name="wpsc_update_quantity" value="true" />
-               <input type="submit" value="<?php _e('Update', 'wpsc'); ?>" name="submit" />
+               <input type="submit" value="<?php _e('Update', 'wpsc'); ?>" />
             </form>
          </td>
 
@@ -77,7 +77,7 @@ endif;
                <input type="hidden" name="quantity" value="0" />
                <input type="hidden" name="key" value="<?php echo wpsc_the_cart_item_key(); ?>" />
                <input type="hidden" name="wpsc_update_quantity" value="true" />
-               <input type="submit" value="<?php _e('Remove', 'wpsc'); ?>" name="submit" />
+               <input type="submit" value="<?php _e('Remove', 'wpsc'); ?>" />
             </form>
          </td>
       </tr>
@@ -474,7 +474,7 @@ endif;
                <input type='hidden' value='yes' name='agree' />
             <?php endif; ?>
                <input type='hidden' value='submit_checkout' name='wpsc_action' />
-               <input type='submit' value='<?php _e('Purchase', 'wpsc');?>' name='submit' class='make_purchase wpsc_buy_button' />
+               <input type='submit' value='<?php _e('Purchase', 'wpsc');?>' class='make_purchase wpsc_buy_button' />
          </span>
       </div>
 


### PR DESCRIPTION
If you hijack the form submission on the checkout page to run some javascript before the form gets submitted, it's then difficult(*) to make the JS submit the form. This is because the submit buttons have a name of "submit" - overriding the submit() method normally used to trigger form submission from JQuery:

See:
http://stackoverflow.com/questions/12853765/jquery-howto-submit-form-that-has-submit-button-with-the-name-submit

The pull request attached removes the names from the checkout fields. 

(*) I'm hoping it's not actually impossible or the plugin I'm working on is a dead-end, but at the very least it's annoyingly difficult. 
