### PR TITLE
not passing 2 params to wpsc_the_category_title with the_title filter

### DIFF
--- a/wpsc-includes/theme.functions.php
+++ b/wpsc-includes/theme.functions.php
@@ -1362,7 +1362,7 @@ function wpsc_enable_page_filters( $excerpt = '' ) {
 	add_filter( 'the_content', 'wpsc_products_page', 1 );
 	add_filter( 'the_content', 'wpsc_single_template',12 );
 	add_filter( 'archive_template','wpsc_the_category_template');
-	add_filter( 'the_title', 'wpsc_the_category_title',10,2 );
+	add_filter( 'the_title', 'wpsc_the_category_title',10 );
 	add_filter( 'the_content', 'wpsc_place_shopping_cart', 12 );
 	add_filter( 'the_content', 'wpsc_transaction_results', 12 );
 	add_filter( 'the_content', 'wpsc_user_log', 12 );


### PR DESCRIPTION
Gary was just a bit to fast tonight. I meant to put this in with my other commits fixing wpsc_the_category_title but he merged them before I could get to adding it.

With the code committed earlier we will see a debug notice in WPEC core on the Add Product/Product list admin pages. `the_title` filter passed 2 params so this kills passing the second one thus killing the debug notice.
