### PR TITLE
Re-code product thumbnail functions to prioritise use of post thumbnail ...

### DIFF
--- a/wpsc-includes/product-template.php
+++ b/wpsc-includes/product-template.php
@@ -1262,7 +1262,6 @@ function wpsc_the_product_thumbnail( $width = null, $height = null, $product_id 
 	}
 
 	// Calculate the height based on the ratio of the original dimensions.
-	// Blame Cameron if this is buggy :P
 	if ( $height == 0 || $width == 0 ) {
 		$attachment_meta = get_post_meta( $thumbnail_id, '_wp_attachment_metadata', false );
 		$original_width  = $attachment_meta[0]['width'];


### PR DESCRIPTION
...if available to reduce unnecessary requests.

In wpsc_the_product_image() check if there is a post thumbnail first before getting first child image as this saves requests.

Can also use wpsc_the_product_thumbnail_id() to avoid repetitive code.

Plus a bit of code tidy.
