### PR TITLE
Filter provided parameters in Add to Cart

### DIFF
--- a/wpsc-includes/ajax.functions.php
+++ b/wpsc-includes/ajax.functions.php
@@ -76,7 +76,7 @@ function wpsc_add_to_cart() {
 	if ( isset($_POST['donation_price']) && ((float)$_POST['donation_price'] > 0 ) ) {
 		$provided_parameters['provided_price'] = (float)$_POST['donation_price'];
 	}
-	$parameters = array_merge( $default_parameters, (array)$provided_parameters );
+	$parameters = array_merge( $default_parameters, apply_filters( 'wpsc_add_to_cart_parameters', $provided_parameters) );
 
 	$state = $wpsc_cart->set_item( $product_id, $parameters );
 


### PR DESCRIPTION
Add new filter 'wpsc_add_to_cart_parameters' to provided_parameters
during add_to_cart ajax action

This allows a external plugin to set additional information re: product being added to cart. In this case, my bakery client is setting a "pickup" date. I can't find anywhere else in the logic to affect the shopping cart item.
