### PR TITLE
Adds new filter over provided_parameters in Add to Cart ajax action

### DIFF
--- a/wpsc-includes/ajax.functions.php
+++ b/wpsc-includes/ajax.functions.php
@@ -71,7 +71,7 @@ function wpsc_add_to_cart() {
 		$provided_parameters['quantity'] = (int) $_POST['wpsc_quantity_update'];
 	}
 
-	if ( isset( $_POST['is_customisable'] ) &&  
+	if ( isset( $_POST['is_customisable'] ) &&
 		'true' == $_POST['is_customisable'] ) {
 		$provided_parameters['is_customisable'] = true;
 


### PR DESCRIPTION
I can find no other way to add a custom parameter to the cart items. This allows third-parties to affect the provided parameters prior to inserting them into the cart_item.

My use case: my bakery client needs to add a pickup date to the cart item
