### PR TITLE
Check if 'subcategory_container' is set.

### DIFF
--- a/wpsc-includes/category.functions.php
+++ b/wpsc-includes/category.functions.php
@@ -309,7 +309,7 @@ function wpsc_display_category_loop($query, $category_html, &$category_branch = 
 		$category_count_html =  $start_element.$category_count.$end_element;
 
 
-		if($sub_categories != '' && isset( $query['subcategory_container'] ) ) {
+		if ( isset( $query['subcategory_container'] ) && ! empty( $sub_categories ) ) {
 			$start_element = $query['subcategory_container']['start_element'];
 			$end_element = $query['subcategory_container']['end_element'];
 			$sub_categories = $start_element.$sub_categories.$end_element;


### PR DESCRIPTION
Causes an error if you don't want to output subcategories using wpsc_print_subcategory() in templates.
