### PR TITLE
Fix selected state for purchase status links in Sales Log list.

### DIFF
--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -290,7 +290,7 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 			'all' => sprintf(
 				'<a href="%s" %s>%s</a>',
 				esc_url( $all_href ),
-				sanitize_html_class( $all_class ),
+				$all_class,
 				$all_text
 			),
 		);
@@ -316,7 +316,7 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 			$views[$status] = sprintf(
 				'<a href="%s" %s>%s</a>',
 				esc_url( $href ),
-				sanitize_html_class( $class ),
+				$class,
 				$text
 			);
 		}


### PR DESCRIPTION
The `current` class is not applied correctly.

First a string is created `class="current"` but then the whole string is escaped using sanitize_html_class() which strips the equals sign and quotes.

In fact there is no need to escape here as we are explicitly specify the correct HTML to insert.
