### PR TITLE
Added filters to the rates in the usps shipping

### DIFF
--- a/wpsc-shipping/usps_20.php
+++ b/wpsc-shipping/usps_20.php
@@ -607,7 +607,7 @@ class ash_usps{
     	        $temp_rate = $wpec_ash_xml->get("Rate",$postage);
     	        $rate = (!empty($temp_rate)) ? $temp_rate[0] : 0.0;
     	        if (!empty($service_name)){
-    	            $temp[$service_name] = apply_filters('wpec_usps_domestic_rate', $rate, $service_name);
+    	            $temp[$service_name] = apply_filters( 'wpsc_usps_domestic_rate', $rate, $service_name );
     	        }
 	        }
 	        array_push($package_services, $temp);
@@ -637,7 +637,7 @@ class ash_usps{
 	        $temp_rate = $wpec_ash_xml->get("Postage",$service);
 	        $rate = (!empty($temp_rate)) ? $temp_rate[0] : 0.0;
 	        if (!empty($service_name)){
-	            $service_table[$service_name] = apply_filters('wpec_usps_intl_rate', $rate, $service_name);
+	            $service_table[$service_name] = apply_filters( 'wpsc_usps_intl_rate', $rate, $service_name );
 	        }
 	    }
 	    return $service_table;


### PR DESCRIPTION
Added two filters for both International and Domestic shipping rates so plugins can hook them and apply any additional fees, etc. without altering the WP-e-Commerce core code.  Also fixed variable being checked.
