### PR TITLE
Added shipwire option to installer

### DIFF
--- a/wpsc-core/wpsc-installer.php
+++ b/wpsc-core/wpsc-installer.php
@@ -142,6 +142,7 @@ function wpsc_install() {
 	add_option( 'do_not_use_shipping', '1', '', 'yes' );
 
 	add_option( 'postage_and_packaging', '0','', 'yes' );
+    add_option( 'shipwire', '0', '', 'yes' );
 
 	add_option( 'purch_log_email', '', '', 'yes' );
 	add_option( 'return_email', '', '', 'yes' );


### PR DESCRIPTION
The shipwire option cannot be saved in the **Shipping** settings since a default _value/option_ wasn't being created upon install of WP-e-Commerce.
