### PR TITLE
Improve tax admin page

### DIFF
--- a/wpsc-admin/ajax.php
+++ b/wpsc-admin/ajax.php
@@ -736,19 +736,6 @@ function _wpsc_ajax_add_tax_rate() {
 			);
 			$returnable = $wpec_taxes_controller->wpec_taxes_build_select_options( $regions, 'region_code', 'name', $default_option, $select_settings );
 			break;
-		case 'wpec_taxes_build_rates_form':
-			$key = $_REQUEST['current_key'];
-			$returnable = $wpec_taxes_controller->wpec_taxes_build_form( $key );
-			break;
-		case 'wpec_taxes_build_bands_form':
-			$key = $_REQUEST['current_key'];
-			//get a new key if a band is already defined for this key
-			while($wpec_taxes_controller->wpec_taxes->wpec_taxes_get_band_from_index($key))
-			{
-				$key++;
-			}
-			$returnable = $wpec_taxes_controller->wpec_taxes_build_form( $key, false, 'bands' );
-			break;
 	}// switch
 
 	return array(

--- a/wpsc-admin/css/settingspage.css
+++ b/wpsc-admin/css/settingspage.css
@@ -425,15 +425,12 @@ table.form-table td .updated.shipwire-update {
 
 /* tax */
 
-.wpec-taxes-form-field {
-	display: inline-block;
-	margin-right: 8px;
-}
-
-.wpec-taxes-form-field label {
-	margin-right: 5px;
-}
 
 .wpsc-tax-bands-row, .wpsc-tax-rates-row {
 	line-height: 3.2;
+}
+
+.wpsc-tax-bands-row.prototype,
+.wpsc-tax-rates-row.prototype {
+	display: none;
 }

--- a/wpsc-admin/includes/settings-tabs/taxes.php
+++ b/wpsc-admin/includes/settings-tabs/taxes.php
@@ -152,19 +152,23 @@ class WPSC_Settings_Tab_Taxes extends WPSC_Settings_Tab {
 			<!--Start Taxes Output-->
 			<table class='widefat page fixed ui-sortable'>
 				<thead>
-					<th scope='col'><?php _e( 'Market', 'wpsc' ); ?></th>
-					<th scope='col'><?php _e( 'Tax Rate', 'wpsc' ); ?></th>
+					<th scope='col' width='60%'><?php _e( 'Market', 'wpsc' ); ?></th>
+					<th scope='col' width='10%'><?php _e( 'Tax Rate', 'wpsc' ); ?></th>
 					<th scope='col'><?php _e( 'Tax Shipping?', 'wpsc' ); ?></th>
-					<th scope='col'><?php _e( 'Actions', 'wpsc' ); ?></th>
+					<th scope='col' style='width: 60px'><?php _e( 'Actions', 'wpsc' ); ?></th>
 				</thead>
 				<tbody>
 					<?php
-						// TODO: Refactor to get rid of the need for wpec_taxes_build_form(). It's a horribly written function.
 						$tax_rates = $wpec_taxes_controller->wpec_taxes->wpec_taxes_get_rates();
+						echo $wpec_taxes_controller->wpsc_build_taxes_row( 'rates', 'prototype', array( 'row_class' => 'prototype' ) );
+						if ( count( $tax_rates ) === 0 ) {
+							echo $wpec_taxes_controller->wpsc_build_taxes_row( 'rates', 0, null );
+						}
 						$tax_rate_count = 0;
 						if ( ! empty( $tax_rates ) ) {
 							foreach ( $tax_rates as $tax_rate ) {
-								echo $wpec_taxes_controller->wpec_taxes_build_form( $tax_rate_count, $tax_rate );
+								// OLD: echo $wpec_taxes_controller->wpec_taxes_build_form( $tax_rate_count, $tax_rate );
+								echo $wpec_taxes_controller->wpsc_build_taxes_row( 'rates', $tax_rate_count, $tax_rate );
 								$tax_rate_count++;
 							}
 						}
@@ -172,10 +176,6 @@ class WPSC_Settings_Tab_Taxes extends WPSC_Settings_Tab {
 				</tbody>
 			</table>
 			<!--End Taxes Output-->
-			<p id="wpsc-add-tax-rates">
-				<a href="#"><?php esc_html_e( 'Add New Tax Rate', 'wpsc' ); ?></a>
-				<img src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" class="ajax-feedback" title="" alt="" />
-			</p>
 		</div>
 		<div id='wpec-taxes-bands-container'>
 			<h3><?php esc_html_e( 'Tax Bands', 'wpsc' ); ?></h3>
@@ -187,27 +187,29 @@ class WPSC_Settings_Tab_Taxes extends WPSC_Settings_Tab {
 				<table class='widefat page fixed ui-sortable'>
 					<thead>
 						<th scope='col'><?php _e( 'Band Name', 'wpsc' ); ?></th>
-						<th scope='col'><?php _e( 'Market', 'wpsc' ); ?></th>
-						<th scope='col'><?php _e( 'Tax Rate', 'wpsc' ); ?></th>
-						<th scope='col'><?php _e( 'Actions', 'wpsc' ); ?></th>
+						<th scope='col' width="50%"><?php _e( 'Market', 'wpsc' ); ?></th>
+						<th scope='col' width='20%'><?php _e( 'Tax Rate', 'wpsc' ); ?></th>
+						<th scope='col' style='width: 60px'><?php _e( 'Actions', 'wpsc' ); ?></th>
 					</thead>
 					<tbody>
 						<?php
 							$tax_bands = $wpec_taxes_controller->wpec_taxes->wpec_taxes_get_bands();
+							echo $wpec_taxes_controller->wpsc_build_taxes_row( 'bands', 'prototype', array( 'row_class' => 'prototype' ) );
+							if ( count( $tax_bands ) === 0 ) {
+								echo $wpec_taxes_controller->wpsc_build_taxes_row( 'bands', 0, null );
+							}
 							$tax_band_count = 0;
 							if ( ! empty( $tax_bands ) ) {
 								foreach ( $tax_bands as $tax_band ) {
-									echo $wpec_taxes_controller->wpec_taxes_build_form( $tax_band_count, $tax_band, 'bands' );
+									// OLD: echo $wpec_taxes_controller->wpec_taxes_build_form( $tax_band_count, $tax_band, 'bands' );
+									echo $wpec_taxes_controller->wpsc_build_taxes_row( 'bands', $tax_band_count, $tax_band );
 									$tax_band_count++;
 								}
 							}
 						?>
+
 					</tbody>
 				</table>
-				<p id="wpsc-add-tax-bands">
-					<a href="#"><?php _e( 'Add New Tax Band', 'wpsc' ); ?></a>
-					<img src="<?php echo esc_url( admin_url( 'images/wpspin_light.gif' ) ); ?>" class="ajax-feedback" title="" alt="" />
-				</p>
 			</div>
 		</div><!--wpec-taxes-bands-container-->
 		<?php

--- a/wpsc-admin/js/settings-page.js
+++ b/wpsc-admin/js/settings-page.js
@@ -694,9 +694,10 @@
 		event_init : function() {
 			var wrapper = $('#options_taxes');
 
-			wrapper.on( 'click' , '#wpsc-add-tax-rates a'        , WPSC_Settings_Page.Taxes.event_add_tax_rate);
+			wrapper.on( 'click' , '.wpsc-button-minus'           , function () { return false; } );
+			wrapper.on( 'click' , '.wpsc-taxes-rates-add'        , WPSC_Settings_Page.Taxes.event_add_tax_rate);
 			wrapper.on( 'click' , '.wpsc-taxes-rates-delete'     , WPSC_Settings_Page.Taxes.event_delete_tax_rate);
-			wrapper.on( 'click' , '#wpsc-add-tax-bands a'        , WPSC_Settings_Page.Taxes.event_add_tax_band);
+			wrapper.on( 'click' , '.wpsc-taxes-bands-add'        , WPSC_Settings_Page.Taxes.event_add_tax_band);
 			wrapper.on( 'click' , '.wpsc-taxes-bands-delete'     , WPSC_Settings_Page.Taxes.event_delete_tax_band);
 			wrapper.on( 'change', '.wpsc-taxes-country-drop-down', WPSC_Settings_Page.Taxes.event_country_drop_down_changed);
 		},
@@ -710,8 +711,8 @@
 				post_data = {
 					action            : 'add_tax_rate',
 					wpec_taxes_action : 'wpec_taxes_get_regions',
-					current_key       : c.data('key'),
-					taxes_type        : c.data('type'),
+					current_key       : c.data('row-key'),
+					taxes_type        : c.data('row-mode'),
 					country_code      : c.val(),
 					nonce             : WPSC_Settings_Page.add_tax_rate_nonce
 				},
@@ -744,6 +745,9 @@
 		 */
 		event_delete_tax_rate : function() {
 			$(this).parents('.wpsc-tax-rates-row').remove();
+			if ($('.wpsc-tax-rates-row').size() === 1) {
+				WPSC_Settings_Page.Taxes.add_field('rates');
+			}
 			return false;
 		},
 
@@ -762,6 +766,9 @@
 		 */
 		event_delete_tax_band : function() {
 			$(this).parents('.wpsc-tax-bands-row').remove();
+			if ($('.wpsc-tax-bands-row').size() === 1) {
+				WPSC_Settings_Page.Taxes.add_field('bands');
+			}
 			return false;
 		},
 
@@ -771,24 +778,14 @@
 		 * @since 3.8.8
 		 */
 		add_field : function(type) {
-			var button_wrapper = $('#wpsc-add-tax-' + type),
+			var tbody = $('#wpec-taxes-' + type + ' tbody'),
 				count = $('.wpsc-tax-' + type + '-row').size(),
-				post_data = {
-					action            : 'add_tax_rate',
-					wpec_taxes_action : 'wpec_taxes_build_' + type + '_form',
-					current_key       : count,
-					nonce             : WPSC_Settings_Page.add_tax_rate_nonce
-				},
-				ajax_callback = function(response) {
-					if (! response.is_successful) {
-						alert(response.error.messages.join("\n"));
-						return;
-					}
-					button_wrapper.before(response.obj.content).find('img').toggleClass('ajax-feedback-active');
-				};
-
-			button_wrapper.find('img').toggleClass('ajax-feedback-active');
-			$.wpsc_post(post_data, ajax_callback);
+				new_prototype_row = $('#wpsc-taxes-' + type + '-row-prototype').clone();
+			new_prototype_row.removeClass('prototype');
+			new_prototype_row.attr('id', new_prototype_row.attr('id').replace(/prototype/g, count));
+			new_prototype_row.attr('data-row-key', new_prototype_row.attr('data-row-key').replace(/prototype/g, count));
+			new_prototype_row.html( new_prototype_row.html().replace(/prototype/g, count) );
+			tbody.append(new_prototype_row);
 		}
 	};
 	$(WPSC_Settings_Page).on('wpsc_settings_tab_loaded_taxes', WPSC_Settings_Page.Taxes.event_init);


### PR DESCRIPTION
Improves the layout of the taxes admin page tab. 

![Google ChromeScreenSnapz016](https://f.cloud.github.com/assets/1079437/400382/a38d87ec-a8a0-11e2-8e96-f543fdf81350.png)

Adds new i18n strings. 

I'll be honest and say this isn't as good as it could be. I feel like the tax rates and tax bands fields could look more like the Checkout Form Fields table, or at least like the Custom Fields metabox.
