### PR TITLE
Hotfix for Buy Now functionality

### DIFF
--- a/wpsc-includes/ajax.functions.php
+++ b/wpsc-includes/ajax.functions.php
@@ -136,8 +136,10 @@ function wpsc_empty_cart() {
 	global $wpsc_cart;
 	$wpsc_cart->empty_cart( false );
 
-	$output = _wpsc_ajax_get_cart( false );
-	die( json_encode( $output ) );
+	if( defined('DOING_AJAX') && DOING_AJAX ){
+		$output = _wpsc_ajax_get_cart( false );
+		die( json_encode( $output ) );
+	}
 }
 
 add_action( 'wp_ajax_empty_cart'       , 'wpsc_empty_cart' );

--- a/wpsc-merchants/paypal-standard.merchant.php
+++ b/wpsc-merchants/paypal-standard.merchant.php
@@ -865,7 +865,7 @@ $output .= "
 }
 
 function _wpsc_buy_now_callback() {
-	global $wpsc_cart, $user_ID;
+	global $wpsc_cart, $user_ID, $paypal_url;
 
 	$paypal_url = get_option( 'paypal_multiple_url' );
 	$_POST['custom_gateway'] = 'wpsc_merchant_paypal_standard';


### PR DESCRIPTION
There are two errors related to wrapping conditions with DOING_AJAX that 1) cause a fatal error (since no value is returned if we aren't DOING_AJAX) and 2) wpsc_empty_cart shouldn't die if we aren't DOING_AJAX
