### PR TITLE
Suggested 'wpsc_vargrp_name' filter to allow customised display of variation group names

### DIFF
--- a/wpsc-includes/product-template.php
+++ b/wpsc-includes/product-template.php
@@ -1450,12 +1450,11 @@ function wpsc_display_product_multicurrency() {
 
 /**
  * wpsc variation group name function
- * @return string - the variaton group name
+ * @return string - the variation group name
  */
 function wpsc_the_vargrp_name() {
-	// get the variation group name;
 	global $wpsc_variations;
-	return $wpsc_variations->variation_group->name;
+	return apply_filters( 'wpsc_vargrp_name', $wpsc_variations->variation_group->name, $wpsc_variations->variation_group );
 }
 
 /**


### PR DESCRIPTION
It's nice to be able to label variation groups one way in the admin, but then perhaps display differently on the front-end.

For example I might have 2 variation groups "Shoe Size" and "Chest Size" but want to show them both as "Size" on the front end.

This filter allows customised display of these names if required and ensures you can change it in places that you can;t customise through the templates like in the wpsc_add_to_cart_button() function.
