### PR TITLE
Allow Spaces in Product Image File Names/URLs

### DIFF
--- a/wpsc-includes/product-template.php
+++ b/wpsc-includes/product-template.php
@@ -1284,6 +1284,10 @@ function wpsc_the_product_thumbnail( $width = null, $height = null, $product_id 
 	if ( ! empty( $thumbnail ) && is_ssl() )
 		$thumbnail = str_replace( 'http://', 'https://', $thumbnail );
 
+	// WordPress's esc_url() function strips out spaces, so encode them here to ensure they don't get stripped out
+	// Ref: http://core.trac.wordpress.org/ticket/23605
+	$thumbnail = str_replace( ' ', '%20', $thumbnail );
+
 	return $thumbnail;
 }
 


### PR DESCRIPTION
Older WP e-Commerce installations can have uploaded product images with file names that contain spaces.

For these products, trying to view the product's full sized image does not work because due to a bug in WordPress (http://core.trac.wordpress.org/ticket/23605), spaces are removed from the image link/path.

This bug affects individual product pages, and any other category pages that display the product's image.

This fix is a simple workaround, which ensures that spaces in image file names are preserved.

When upgrading some older WPEC sites to the latest 3.8.11.1 version, I noticed this problem.
