### PR TITLE
Make wpsc_the_product_thumbnail_id() filterable and include default fallback functionality

### DIFF
--- a/wpsc-includes/product-template.php
+++ b/wpsc-includes/product-template.php
@@ -1133,18 +1133,14 @@ function wpsc_check_display_type(){
  * Get The Product Thumbnail ID
  *
  * If no post thumbnail is set, this will return the ID of the first image
- * associated with a product.
+ * associated with a product. If no image is found and the product is a variation it will
+ * then try getting the parent product's image instead.
  *
  * @param  int  $product_id  Product ID
  * @return int               Product thumbnail ID
  */
 function wpsc_the_product_thumbnail_id( $product_id ) {
 	$thumbnail_id = null;
-
-	// If variation, get parent product
-	$product = get_post( $product_id );
-	if ( $product->post_parent > 0 )
-		$product_id = $product->post_parent;
 
 	// Use product thumbnail...
 	if ( has_post_thumbnail( $product_id ) ) {
@@ -1162,8 +1158,30 @@ function wpsc_the_product_thumbnail_id( $product_id ) {
 		if ( ! empty( $attached_images ) )
 			$thumbnail_id = $attached_images[0]->ID;
 	}
+	return apply_filters( 'wpsc_the_product_thumbnail_id', $thumbnail_id, $product_id );
+}
+
+/**
+ * Maybe Get The Parent Product Thumbnail ID
+ *
+ * If no thumbnail is found and the product is a variation it will
+ * then try getting the parent product's image instead.
+ *
+ * @param  int  $thumbnail_id  Thumbnail ID
+ * @param  int  $product_id    Product ID
+ * @return int                 Product thumbnail ID
+ *
+ * @uses   wpsc_the_product_thumbnail_id()  Get the product thumbnail ID
+ */
+function wpsc_maybe_get_the_parent_product_thumbnail_id( $thumbnail_id, $product_id ) {
+	if ( ! $thumbnail_id ) {
+		$product = get_post( $product_id );
+		if ( $product->post_parent > 0 )
+			$thumbnail_id = wpsc_the_product_thumbnail_id( $product->post_parent );
+	}
 	return $thumbnail_id;
 }
+add_filter( 'wpsc_the_product_thumbnail_id', 'wpsc_maybe_get_the_parent_product_thumbnail_id', 10, 2 );
 
 /**
 * Regenerate size metadata of a thumbnail in case it's missing.


### PR DESCRIPTION
PR for issue #440

This ensures that the wpsc_the_product_thumbnail_id() is flexible enough for people who want to use it with variations.

If passed a variation ID, this function now tries to return the image assigned to that variation. The result of this function is filtered with 'wpsc_the_product_thumbnail_id'.

We then hook into this filter with wpsc_maybe_get_the_parent_product_thumbnail_id() to provide default behaviour to use parent product's image if variation has no image.

If a user wants to disable this behaviour (they may want to handle missing variation image differently instead of defaulting top parent) they can remove it with:

```
remove_filter( 'wpsc_the_product_thumbnail_id', 'wpsc_maybe_get_the_parent_product_thumbnail_id', 10, 2 );
```
