### PR TITLE
Early JS push to disable display box with mandatory checked

### DIFF
--- a/wpsc-admin/js/settings-page.js
+++ b/wpsc-admin/js/settings-page.js
@@ -328,15 +328,19 @@
 
 			WPSC_Settings_Page.Checkout.new_field_count = $('.new-field').length;
 
-            wrapper.find( '.mandatorycol input[type="checkbox"]').each( function( event ){
-                var displaycol = $(this).parents('.mandatorycol').siblings('.displaycol');
+			/**
+			 * Finding checkboxes that are mandatory and disabling the display option.
+			 * If it's mandatory you no have choice for display.
+			 */
+			wrapper.find( '.mandatorycol input[type="checkbox"]').each( function(){
+				var displaycol = $(this).parents('.mandatorycol').siblings('.displaycol');
 
-                if ( $(this).is(':checked') ){
-                    $(displaycol).find('input[type="checkbox"]').prop('checked', true ).attr( 'disabled', 'disabled' );
-                } else {
-                    $(displaycol).find('input[type="checkbox"]').attr( 'disabled', this.checked );
-                }
-            });
+				if ( $(this).is(':checked') ){
+					$(displaycol).find('input[type="checkbox"]').prop('checked', true ).attr( 'disabled', 'disabled' );
+				} else {
+					$(displaycol).find('input[type="checkbox"]').attr( 'disabled', this.checked );
+				}
+			});
 
 		},
 
@@ -568,16 +572,20 @@
 			return false;
 		},
 
-        event_disabled_toggeled : function() {
+		/**
+		 * Disables and checks the display option if you make a field mandatory. If you uncheck
+		 * mandatory then it just enables you to uncheck the display box.
+		 */
+		event_disabled_toggeled : function() {
 
-            var displaycol = $(this).parents('.mandatorycol').siblings('.displaycol');
+			var displaycol = $(this).parents('.mandatorycol').siblings('.displaycol');
 
-            if ( $(this).is(':checked') ){
-                $(displaycol).find('input[type="checkbox"]').prop('checked', true ).attr( 'disabled', 'disabled' );
-            } else {
-                 $(displaycol).find('input[type="checkbox"]').attr( 'disabled', this.checked );
-            }
-        },
+			if ( $(this).is(':checked') ){
+				$(displaycol).find('input[type="checkbox"]').prop('checked', true ).attr( 'disabled', 'disabled' );
+			} else {
+				 $(displaycol).find('input[type="checkbox"]').attr( 'disabled', this.checked );
+			}
+		},
 
 		/**
 		 * This hack is to make sure the dragged row has 100% width


### PR DESCRIPTION
Goes with #419

Just a really early stab at dealing with this, especially since I haven't written JS quite as I see it in the template yet.

All this does is alert that something happened since it's late and I'm not thinking as well as I should.

Is it formatted properly?

My thoughts are that on toggle we will check if it is indeed :checked and if so disable the matching 'display' checkbox.

A question would be, when we load the page should we be disabling the display checkboxes that have a mandatory checkbox already set  from server side, or should we be firing a JS event to do that.

A JS event would leave all the checkboxes accessible in the event no JS is loaded (not sure how big that use case is) but not have the UI feedback. If we do it server side, then we get the UI feedback but some checkboxes are disabled till we get a page refresh.
