### PR TITLE
Remove show_shipping_options tied to onchange (in coupons??)

### DIFF
--- a/wpsc-admin/display-coupon-add.php
+++ b/wpsc-admin/display-coupon-add.php
@@ -30,7 +30,7 @@
 							<label for="add_discount_type"><?php _e( 'Discount Type', 'wpsc' ); ?></label>
 						</th>
 						<td>
-							<select name='add_discount_type' id='add_discount_type' onchange = 'show_shipping_options();'>
+							<select name='add_discount_type' id='add_discount_type'>
 								<option value='0'><?php _e( 'Fixed Amount', 'wpsc' ); ?></option>
 								<option value='1'><?php _e( 'Percentage', 'wpsc' ); ?></option>
 								<option value='2'><?php _e( 'Free shipping', 'wpsc' ); ?></option>

--- a/wpsc-admin/display-coupon-edit.php
+++ b/wpsc-admin/display-coupon-edit.php
@@ -48,7 +48,7 @@ $coupon    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `" . WPSC_TABLE_COUP
 						</th>
 						<td>
 							<?php $type = absint( $coupon['is-percentage'] ); ?>
-							<select name='edit_discount_type' id='edit_discount_type' onchange='show_shipping_options();'>
+							<select name='edit_discount_type' id='edit_discount_type'>
 								<option value='0'<?php selected( 0, $type ); ?>><?php _e( 'Fixed Amount', 'wpsc' ); ?></option>
 								<option value='1'<?php selected( 1, $type ); ?>><?php _e( 'Percentage', 'wpsc' ); ?></option>
 								<option value='2'<?php selected( 2, $type ); ?>><?php _e( 'Free shipping', 'wpsc' ); ?></option>


### PR DESCRIPTION
These onchange functions don't belong here. Not applicable in coupons - probably copied and pasted.
