### PR TITLE
Allow default dimension and weight units to be filterable.

### DIFF
--- a/wpsc-admin/display-items.page.php
+++ b/wpsc-admin/display-items.page.php
@@ -117,22 +117,7 @@ function _wpsc_manage_products_column_weight( $post, $post_id, $has_variations )
 
 	$unit = $product_data['meta']['_wpsc_product_metadata']['weight_unit'];
 
-	switch( $unit ) {
-		case "pound":
-			$unit = __(" lbs.", "wpsc");
-		break;
-		case "ounce":
-			$unit = __(" oz.", "wpsc");
-		break;
-		case "gram":
-			$unit = __(" g", "wpsc");
-		break;
-		case "kilograms":
-		case "kilogram":
-			$unit = __(" kgs.", "wpsc");
-		break;
-	}
-	echo $weight.$unit;
+	echo $weight . wpsc_weight_unit_display( $unit );
 	echo '<div id="inline_' . $post->ID . '_weight" class="hidden">' . esc_html( $weight ) . '</div>';
 }
 add_action( 'wpsc_manage_products_column_weight', '_wpsc_manage_products_column_weight', 10, 3 );

--- a/wpsc-admin/includes/display-items-functions.php
+++ b/wpsc-admin/includes/display-items-functions.php
@@ -433,6 +433,21 @@ function wpsc_weight_units() {
 	);
 }
 
+function wpsc_weight_unit_display( $unit ) {
+	switch ( $unit ) {
+		case 'pound' :
+			return __( ' lbs.', 'wpsc' );
+		case 'ounce' :
+			return __( ' oz.', 'wpsc' );
+		case 'gram' :
+			return __( ' g', 'wpsc' );
+		case 'kilograms' :
+		case 'kilogram' :
+			return __( ' kgs.', 'wpsc' );
+	}
+	return '';
+}
+
 function wpsc_validate_dimension_unit( $unit = '' ) {
 	$default_unit = apply_filters( 'wpsc_default_dimension_unit', $unit );
 	if ( empty( $unit ) && array_key_exists( $default_unit, wpsc_dimension_units() ) )


### PR DESCRIPTION
Addresses #423

This basically means that you can set the default selected value for weight and dimension dropdown menus in the admin.

For example to set default unit measurements to grams and cm:

``` php
function my_wpsc_default_weight_unit( $unit ) {
    return 'gram';
}
add_filter( 'wpsc_default_weight_unit', 'my_wpsc_default_weight_unit' );

function my_wpsc_default_dimension_unit( $unit ) {
    return 'cm';
}
add_filter( 'wpsc_default_dimension_unit', 'my_wpsc_default_dimension_unit' );
```
