### PR TITLE
Product out of stock message for variation is not correct

### DIFF
--- a/wpsc-includes/ajax.functions.php
+++ b/wpsc-includes/ajax.functions.php
@@ -97,7 +97,7 @@ function wpsc_add_to_cart() {
 			$quantity = $wpsc_cart->get_remaining_quantity( $product_id, $parameters['variation_values'], $parameters['quantity'] );
 			$cart_messages[] = sprintf( _n( 'Sorry, but there is only %s of this item in stock.', 'Sorry, but there are only %s of this item in stock.', $quantity, 'wpsc' ), $quantity );
 		} else {
-			$cart_messages[] = sprintf( __( 'Sorry, but the item "%s" is out of stock.', 'wpsc' ), $product->post_title	);
+			$cart_messages[] = sprintf( __( 'Sorry, but the item "%s" is out of stock.', 'wpsc' ), get_the_title( $product_id )	);
 		}
 	}
 


### PR DESCRIPTION
When attempting to add a product to a cart that has one of its
variations out of stock the message that is displayed tells the customer
that the main product is out of stock rather than the specific variation
being out of stock. Message changed to use title of current product id
rather than title from post of parent product

Isse #494
