### PR TITLE
Don't use wp_convert_bytes_to_hr() deprecated function

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,7 @@ After upgrading from earlier versions look for link "Update Store". This will up
 * Fix: If AJAX_URL returns HTTPS and Add to Cart is on HTTP, errors
 * Fix: Add to Cart button doesn't work
 * Fix: Can no longer upload customer attachments
+* Fix: Deprecated warning for wp_convert_bytes_to_hr() function in WordPress 3.6
 
 
 = 3.8.11.1 =

--- a/wpsc-admin/includes/product-functions.php
+++ b/wpsc-admin/includes/product-functions.php
@@ -7,7 +7,7 @@
  */
 
 function wpsc_get_max_upload_size(){
-	return wp_convert_bytes_to_hr( wp_max_upload_size() );
+	return size_format( wp_max_upload_size() );
 }
 
 /**


### PR DESCRIPTION
As per http://core.trac.wordpress.org/ticket/19067, WordPress 3.6 deprecates the wp_convert_bytes_to_hr() function in favour of the size_format() (which was was added in WordPress 2.3).

Fixes #508.
