### PR TITLE
Allow multiple comma separate categories in coupon conditions.

### DIFF
--- a/wpsc-includes/coupons.class.php
+++ b/wpsc-includes/coupons.class.php
@@ -164,7 +164,7 @@ class wpsc_coupons {
 					$id = $product_data->post_parent;
 
 				$category_condition = $condition['value'];
-				if ( strpos( $category_condition, ',' ) ) {
+				if ( false !== strpos( $category_condition, ',' ) ) {
 					$category_condition = explode( ',', $condition['value'] );
 					$category_condition = array_map( 'trim', $cond );
 				}


### PR DESCRIPTION
Would be nice to allow setting of multiple categories in coupon condition to test if product is in ANY of these categories.
![coupon-multi-cat](https://f.cloud.github.com/assets/765285/687965/0855e244-da8a-11e2-83be-b3f7c6e15d2a.png)
