### PR TITLE
Fix wp-e-commerce.js to allow cart to load when caching is enabled

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/page.php
+++ b/wpsc-components/theme-engine-v1/helpers/page.php
@@ -349,7 +349,7 @@ function wpsc_enqueue_user_script_and_css() {
 			'ajaxurl'   => admin_url( 'admin-ajax.php', 'relative' ),
 			'spinner'   => esc_url( admin_url( 'images/wpspin_light.gif' ) ),
 			'no_quotes' => __( 'It appears that there are no shipping quotes for the shipping information provided.  Please check the information and try again.', 'wpsc' ),
-			'ajax_get_cart_error' => __( '<i>There was a problem getting the current contents of the shopping cart.</i>', 'wpsc' ),
+			'ajax_get_cart_error' => __( 'There was a problem getting the current contents of the shopping cart.', 'wpsc' ),
 			)
 		);
 

--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -247,8 +247,8 @@ jQuery(document).ready(function ($) {
 			}
 
 			var success = function( response ) {
-				if ( (response!=null) ) {
-					if ( response.fancy_notification ) {
+				if ( ( response ) ) {
+					if ( response.hasOwnProperty('fancy_notification') && response.fancy_notification ) {
 						if ( jQuery( '#fancy_notification_content' ) ) {
 							jQuery( '#fancy_notification_content' ).html( response.fancy_notification );
 							jQuery( '#loading_animation').css( 'display', 'none' );


### PR DESCRIPTION
Addresses ".load" not firing issue with get_art ajax functionality (as discussed with @JustinSainton).

Also replaced '.load' with '.ready' for related events

Noticed a couple spots in code where there might be a need for another change, but I didn't understand what the code was trying to do so I left it alone.  See the issue #534  comments.
