### PR TITLE
Allow gateway setting forms to be methods of a class

### DIFF
--- a/wpsc-components/merchant-core-v2/helpers/admin.php
+++ b/wpsc-components/merchant-core-v2/helpers/admin.php
@@ -78,7 +78,7 @@ function _wpsc_filter_merchant_v2_gateway_form( $form, $selected_gateway ) {
 		$output = ob_get_clean();
 		$return = array(
 			'name'              => $selected_gateway_data['name'],
-			'form_fields'       => $output . $selected_gateway_data['form'](),
+			'form_fields'       => $output . call_user_func( $selected_gateway_data['form'] ),
 			'has_submit_button' => 0,
 		);
 	}


### PR DESCRIPTION
The current gateway helper code calls the gateway's settings form function directly, using the syntax

$var();

This works fine if the variable is a string containing a function name. If however, the variable is a class and method, in standard call_user_func() format, then this works on PHP 5.4, but not on earlier versions. The attached PR switches to using call_user_func() so that either syntax can be used.
