### PR TITLE
Packing slip filters

### DIFF
--- a/wpsc-admin/includes/purchase-logs-page/packing-slip.php
+++ b/wpsc-admin/includes/purchase-logs-page/packing-slip.php
@@ -104,6 +104,7 @@
 					<th><?php echo esc_html_x( 'Order ID', 'packing slip', 'wpsc' ); ?></th>
 					<th><?php echo esc_html_x( 'Shipping Method', 'packing slip', 'wpsc' ); ?></th>
 					<th><?php echo esc_html_x( 'Payment Method', 'packing slip', 'wpsc' ); ?></th>
+					<?php wpsc_purchaselog_order_summary_headers(); ?>
 				</tr>
 			</thead>
 			<tbody>
@@ -112,6 +113,7 @@
 					<td><?php echo wpsc_purchaselog_details_purchnumber(); ?></td>
 					<td><?php echo wpsc_display_purchlog_shipping_method(); ?></td>
 					<td><?php echo wpsc_display_purchlog_paymentmethod(); ?></td>
+					<?php wpsc_purchaselog_order_summary(); ?>
 				</tr>
 			</tbody>
 		</table>

--- a/wpsc-includes/purchaselogs.class.php
+++ b/wpsc-includes/purchaselogs.class.php
@@ -443,6 +443,16 @@ function wpsc_display_purchlog_paymentmethod() {
 
 }
 
+function wpsc_purchaselog_order_summary_headers() {
+	global $purchlogitem;
+	do_action( 'wpsc_purchaselog_order_summary_headers', $purchlogitem );
+}
+
+function wpsc_purchaselog_order_summary() {
+	global $purchlogitem;
+	do_action( 'wpsc_purchaselog_order_summary', $purchlogitem );
+}
+
 function wpsc_has_purchlog_shipping() {
    global $purchlogitem;
    if ( $purchlogitem->shippinginfo['shippingfirstname']['value'] != '' ) {


### PR DESCRIPTION
This PR includes 2 commits. The first is yet another catch on WPEC accessing properties of shipping modules direct rather than using the methods to access them. The second adds new hooks that allow information to be added to the order summary table on packing slips.
