### PR TITLE
Fixing small errors in USPS settings page

### DIFF
--- a/wpsc-shipping/usps_20.php
+++ b/wpsc-shipping/usps_20.php
@@ -227,8 +227,8 @@ class ash_usps {
 			<td>
 				<div class="ui-widget-content multiple-select">
 					<?php foreach ( $this->services as $label => $service ): ?>
-						<input type="checkbox" id="wpec_usps_srv_<?php esc_attr_e( $service ); ?>" name="wpec_usps[services][]" value="<?php echo esc_attr_e( $service ); ?>" <?php checked( array_search( $service, $wpec_usps_services ) ); ?> />
-				 		<label for="wpec_usps_srv_$service"><?php echo $label; ?></label>
+						<input type="checkbox" id="wpec_usps_srv_<?php esc_attr_e( $service ); ?>" name="wpec_usps[services][]" value="<?php echo esc_attr_e( $service ); ?>" <?php checked( (bool) array_search( $service, $wpec_usps_services ) ); ?> />
+                        <label for="wpec_usps_srv_<?php echo esc_attr_e( $service ) ?>"><?php echo $label; ?></label>
 				 		<br />
 					<?php endforeach; ?>
 				</div>


### PR DESCRIPTION
The label on the USPS shipping options didn't match the input id because of what seems like a typo. That's fixed. I also fixed the shipping options not reflecting in the form properly, by casting the returned value of array_search (the index it was found at) to a bool to make it comparable internally in the checked() function.

The array_search function returns the index at which it was found. In this case, with multiple selections, it was returning (for example) 1, 2, and 3 for different selected shipping options. This resulted in only the first option actually ending up checked, since checked(1) would print the checked text, but checked(2) and checked(3) would not.

Internally, the checked() function does something like this:

```
function checked( $helper, $current = true ) {
    if ( (string) $helper === (string) $current )
        echo "checked='checked'";
}
```

So, only the first checked message would be printed, because:

```
(string) 1 === (string) true; // true
(string) 2 === (string) true; // false
(string) 3 === (string) true; // false
```

By casting the results of array_search to a bool, it only ever compares string casts of booleans, and the numbers don't come into it.
