### PR TITLE
Strict standards fix cat functions

### DIFF
--- a/wpsc-includes/category.functions.php
+++ b/wpsc-includes/category.functions.php
@@ -16,12 +16,12 @@
 * @return array of term objects or empty array if anything went wrong or there were no parents
 */
 function wpsc_get_term_parents( $term_id, $taxonomy ) {
-	$term = &get_term( $term_id, $taxonomy );
+	$term = get_term( $term_id, $taxonomy );
 
 	if( empty( $term->parent ) )
 		return array();
-	$parent = &get_term( $term->parent, $taxonomy );
 
+	$parent = get_term( $term->parent, $taxonomy );
 	if ( is_wp_error( $parent ) )
 		return array();
 


### PR DESCRIPTION
Minor fix to resolve a strict standards warning caused by trying to assign by reference the return value of a function. Also fixes up whitespace in the same func (Separate commits for clarity)
