### PR TITLE
Static method declrations

### DIFF
--- a/wpsc-components/marketplace-core-v1/library/Sputnik.php
+++ b/wpsc-components/marketplace-core-v1/library/Sputnik.php
@@ -102,7 +102,7 @@ class Sputnik {
 		Sputnik_Pointers::bootstrap();
 	}
 
-	public function add_download_link( $message, $notification ) {
+	public static function add_download_link( $message, $notification ) {
 		$cart_contents = $notification->get_purchase_log()->get_cart_contents();
 
 		$products = '';
@@ -325,7 +325,7 @@ class Sputnik {
 		}
 	}
 
-	public function sales_data_postback() {
+	public static function sales_data_postback() {
 		if ( ! isset( $_REQUEST['sales_data'] ) )
 			return;
 


### PR DESCRIPTION
added static to method decrlarations to avoid php warnings like this error type: [2048] call_user_func_array() expects parameter 1 to be a valid callback, non-static method Sputnik::add_download_link() should not be called statically file: H:\web-site-dev\sparkle-gear.com\wp-includes\plugin.php line: 173

Addresses #623
