### PR TITLE
Add message for a combination of variations that's not available.

### DIFF
--- a/wpsc-components/theme-engine-v1/templates/wpsc-default.css
+++ b/wpsc-components/theme-engine-v1/templates/wpsc-default.css
@@ -241,6 +241,11 @@ Author URI: http://instinct.co.nz
 	*zoom:1;
 }
 
+.default_product_display .is_variation,
+.single_product_display .is_variation {
+	display: none;
+}
+
 .default_product_display .in_stock,
 .single_product_display .in_stock {
 	position: relative;
@@ -250,6 +255,8 @@ Author URI: http://instinct.co.nz
 	left:-5px;
 }
 
+.default_product_display .no_variation,
+.single_product_display .no_variation,
 .default_product_display .out_of_stock,
 .single_product_display .out_of_stock {
 	position: relative;

--- a/wpsc-components/theme-engine-v1/templates/wpsc-grid_view.php
+++ b/wpsc-components/theme-engine-v1/templates/wpsc-grid_view.php
@@ -117,6 +117,7 @@ $image_height = get_option('product_image_height');
 								</select></td></tr>
 							<?php endwhile; ?>
                             </table>
+   							<div id="variation_display_<?php echo wpsc_the_product_id(); ?>" class="is_variation"><?php _e('Combination of product variants is not available', 'wpsc'); ?></div>
 						</div><!--close wpsc_variation_forms-->
                         </fieldset>
 								<?php /** the variation group HTML and loop ends here */?>

--- a/wpsc-components/theme-engine-v1/templates/wpsc-products_page.php
+++ b/wpsc-components/theme-engine-v1/templates/wpsc-products_page.php
@@ -139,6 +139,7 @@ $image_width = get_option('product_image_width');
 								</select></td></tr>
 							<?php endwhile; ?>
                             </table>
+   							<div id="variation_display_<?php echo wpsc_the_product_id(); ?>" class="is_variation"><?php _e('Combination of product variants is not available', 'wpsc'); ?></div>
 						</div><!--close wpsc_variation_forms-->
                         </fieldset>
 						<?php } ?>

--- a/wpsc-components/theme-engine-v1/templates/wpsc-single_product.php
+++ b/wpsc-components/theme-engine-v1/templates/wpsc-single_product.php
@@ -106,6 +106,7 @@
 								</select></td></tr>
 							<?php endwhile; ?>
                             </table>
+   							<div id="variation_display_<?php echo wpsc_the_product_id(); ?>" class="is_variation"><?php _e('Combination of product variants is not available', 'wpsc'); ?></div>
 						</div><!--close wpsc_variation_forms-->
                         </fieldset>
 						<?php } ?>

--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -306,6 +306,7 @@ jQuery(document).ready(function ($) {
 		var form_values = jQuery("input[name='product_id'], .wpsc_select_variation",parent_form).serialize() + '&action=update_product_price';
 
 		jQuery.post( wpsc_ajax.ajaxurl, form_values, function(response) {
+			var variation_display = jQuery('div#variation_display_' + prod_id );
 			var stock_display = jQuery('div#stock_display_' + prod_id),
 				price_field = jQuery('input#product_price_' + prod_id),
 				price_span = jQuery('#product_price_' + prod_id + '.pricedisplay, #product_price_' + prod_id + ' .currentprice'),
@@ -322,6 +323,9 @@ jQuery(document).ready(function ($) {
 				} else {
 					stock_display.addClass('out_of_stock').removeClass('in_stock');
 				}
+				variation_display.removeClass('no_variation').addClass('is_variation');
+			} else {
+				variation_display.removeClass('is_variation').addClass('no_variation');
 			}
 
 			stock_display.html(response.variation_msg);

--- a/wpsc-theme/wpsc-default.css
+++ b/wpsc-theme/wpsc-default.css
@@ -236,6 +236,11 @@ Author URI: http://instinct.co.nz
 	*zoom:1;
 }
 
+.default_product_display .is_variation,
+.single_product_display .is_variation {
+	display: none;
+}
+
 .default_product_display .in_stock,
 .single_product_display .in_stock {
 	position: relative;
@@ -245,6 +250,8 @@ Author URI: http://instinct.co.nz
 	left:-5px;
 }
 
+.default_product_display .no_variation,
+.single_product_display .no_variation,
 .default_product_display .out_of_stock,
 .single_product_display .out_of_stock {
 	position: relative;

--- a/wpsc-theme/wpsc-grid_view.php
+++ b/wpsc-theme/wpsc-grid_view.php
@@ -117,6 +117,7 @@ $image_height = get_option('product_image_height');
 								</select></td></tr>
 							<?php endwhile; ?>
                             </table>
+   							<div id="variation_display_<?php echo wpsc_the_product_id(); ?>" class="is_variation"><?php _e('Combination of product variants is not available', 'wpsc'); ?></div>
 						</div><!--close wpsc_variation_forms-->
                         </fieldset>
 								<?php /** the variation group HTML and loop ends here */?>

--- a/wpsc-theme/wpsc-products_page.php
+++ b/wpsc-theme/wpsc-products_page.php
@@ -139,6 +139,7 @@ $image_width = get_option('product_image_width');
 								</select></td></tr>
 							<?php endwhile; ?>
                             </table>
+   							<div id="variation_display_<?php echo wpsc_the_product_id(); ?>" class="is_variation"><?php _e('Combination of product variants is not available', 'wpsc'); ?></div>
 						</div><!--close wpsc_variation_forms-->
                         </fieldset>
 						<?php } ?>

--- a/wpsc-theme/wpsc-single_product.php
+++ b/wpsc-theme/wpsc-single_product.php
@@ -106,6 +106,7 @@
 								</select></td></tr>
 							<?php endwhile; ?>
                             </table>
+   							<div id="variation_display_<?php echo wpsc_the_product_id(); ?>" class="is_variation"><?php _e('Combination of product variants is not available', 'wpsc'); ?></div>
 						</div><!--close wpsc_variation_forms-->
                         </fieldset>
 						<?php } ?>


### PR DESCRIPTION
Hello,
A customer of mine wants to display a message when a variant is not availble of a product.
Some combinations of variants are not practical (like a table-top of 1 meter and a table-frame of 2 meters), so she selects them out. But they can still be ordered.
This patch adds a message to the frontend of the website.
It will also display the message if only half of the variations are selected.

I would also prefer to make the button un-clickable, but that might be a bit harder to do.

Please reply if this patch is acceptable.
