### PR TITLE
Add to cart shoul not empty cart

### DIFF
--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -239,7 +239,9 @@ jQuery(document).ready(function ($) {
 		if(file_upload_elements.length > 0) {
 			return true;
 		} else {
-			form_values = jQuery(this).serialize() + '&action=' + jQuery( 'input[name="wpsc_ajax_action"]' ).val();
+			var action_buttons = jQuery(this).children('input[name="wpsc_ajax_action"]');
+			var action = action_buttons[0].value;
+			form_values = jQuery(this).serialize() + '&action=' + action;
 
 			// Sometimes jQuery returns an object instead of null, using length tells us how many elements are in the object, which is more reliable than comparing the object to null
 			if( jQuery( '#fancy_notification' ).length === 0 ) {


### PR DESCRIPTION
This finds the wpsc_ajax_action inside the current form, instead of document wide.  Avoids picking up other actions that may be associated with other input controls, like the pwsc_ajax_action that may be in the cart widget to empty the cart.

Addresses issue #640
