### PR TITLE
Have the taxonomies & product meta set after children are created when duplicating product.

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -1402,14 +1402,14 @@ function wpsc_duplicate_product_process( $post, $new_parent_id = false ) {
 	// Insert the new template in the post table
 	$new_post_id = wp_insert_post($defaults);
 
+	// Finds children (Which includes product files AND product images), their meta values, and duplicates them.
+	wpsc_duplicate_children( $post->ID, $new_post_id );
+
 	// Copy the taxonomies
 	wpsc_duplicate_taxonomies( $post->ID, $new_post_id, $post->post_type );
 
 	// Copy the meta information
 	wpsc_duplicate_product_meta( $post->ID, $new_post_id );
-
-	// Finds children (Which includes product files AND product images), their meta values, and duplicates them.
-	wpsc_duplicate_children( $post->ID, $new_post_id );
 
 	return $new_post_id;
 }


### PR DESCRIPTION
**Bug fix for the following issue:** Only the first product variant would be shown on the public product listing on a product that had been duplicated (original containing multiple variants).

Turns out only the first term relationship was being kept during the duplication process (public page uses get_terms while admin uses custom query [which is why variants were still being shown there]… missing term relationships leads to missing variants called by get_terms).

Commenting out the wpsc_duplicate_children() function was a quick fix as it's 100% caused by that process, but that wasn't a good route to take. Settled on simply changing the order in which it happens… duplicate children first, and then taxonomies & product meta. _That fixed the issue!_
