### PR TITLE
Missing prefix for the action row functions

### DIFF
--- a/wpsc-admin/display-items.page.php
+++ b/wpsc-admin/display-items.page.php
@@ -558,7 +558,7 @@ function wpsc_update_featured_products() {
 	exit;
 }
 
-add_filter( 'page_row_actions','my_action_row', 10, 2 );
+add_filter( 'page_row_actions','wpsc_action_row', 10, 2 );
 
 /**
  * @param $actions
@@ -570,7 +570,7 @@ add_filter( 'page_row_actions','my_action_row', 10, 2 );
  * @uses esc_url()              Makes sure the URL is safe, we like safe
  * @uses esc_html_x()           Displays translated string with gettext context
  */
-function my_action_row( $actions, $post ) {
+function wpsc_action_row( $actions, $post ) {
 
 	if ( $post->post_type != "wpsc-product" )
 			return $actions;


### PR DESCRIPTION
I have a plugin and there was a compatibility issue, because we both used the "my_action_row" function name, we should add a prefix:) I guess we used the same example code
