### PR TITLE
When permalink is requested for child product (variation) link to parent

### DIFF
--- a/wpsc-includes/misc.functions.php
+++ b/wpsc-includes/misc.functions.php
@@ -898,6 +898,10 @@ function wpsc_show_terms_and_conditions() {
  * @return (string) permalink to product
  */
 function _wpsc_redirect_child_product_permalink( $post_link, $post, $leavename, $sample ) {
+	if ( is_numeric( $post ) ) {
+		$post = get_post( $post );
+	}
+
 	if ( ($post->post_type == 'wpsc-product') && ($post->post_status = 'inherit') && ($post->post_parent != 0 ) ) {
 		$post_link = get_permalink( $post->post_parent );
 	}


### PR DESCRIPTION
Necessary because child products are not generally reachable using a URL with the standard rewrites

Closes #560, #616, #690
