### PR TITLE
Child product post link should be to parent product

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/product.php
+++ b/wpsc-components/theme-engine-v1/helpers/product.php
@@ -35,6 +35,12 @@ function wpsc_product_link( $permalink, $post, $leavename ) {
 	if ($post->post_type != 'wpsc-product')
 		return $permalink;
 
+	// Return permalink to parent product when a permalink is requested for a child product
+	if ( ($post->post_status = 'inherit') && ($post->post_parent != 0) ) {
+		$post_id = $post->post_parent;
+		$post = get_post( $post_id );
+	}
+
 	$permalink_structure = get_option( 'permalink_structure' );
 
 	// This may become customiseable later

--- a/wpsc-includes/misc.functions.php
+++ b/wpsc-includes/misc.functions.php
@@ -890,23 +890,3 @@ function wpsc_show_terms_and_conditions() {
 	echo wpautop( wp_kses_post( get_option( 'terms_and_conditions' ) ) );
 	die();
 }
-
-/** Return permalink to parent product when a permalink is requested for a child product
- * @access private
- *
- * @since 3.8.13
- * @return (string) permalink to product
- */
-function _wpsc_redirect_child_product_permalink( $post_link, $post, $leavename, $sample ) {
-	if ( is_numeric( $post ) ) {
-		$post = get_post( $post );
-	}
-
-	if ( ($post->post_type == 'wpsc-product') && ($post->post_status = 'inherit') && ($post->post_parent != 0 ) ) {
-		$post_link = get_permalink( $post->post_parent );
-	}
-
-	return $post_link;
-}
-
-add_action( 'post_type_link', '_wpsc_redirect_child_product_permalink' , 10, 4 );


### PR DESCRIPTION
Necessary because child products are not generally reachable using a URL with the standard rewrites.  Moved as suggested in previous pull request comments.

Necessary because child products are not generally reachable using a URL with the standard rewrites

Closes #560, #616, #690
