### PR TITLE
Fix USPS Scrambled shipping rates

### DIFF
--- a/wpsc-shipping/usps_20.php
+++ b/wpsc-shipping/usps_20.php
@@ -516,8 +516,8 @@ class ash_usps {
 	 * @param string $response Reference to the $response string
 	 */
 	function _clean_response( &$response ) {
-		$bad_encoding = array( "&amp;lt;sup&amp;gt;&amp;amp;", ";&amp;lt;/sup&amp;gt;" );
-		$good_encoding = array( "<sup>","</sup>" );
+		$bad_encoding = array( "&amp;lt;sup&amp;gt;", ";&amp;lt;/sup&amp;gt;" );
+		$good_encoding = array( "<sup>", "</sup>" );
 		$response = str_replace( $bad_encoding, $good_encoding, $response );
 	}
 


### PR DESCRIPTION
Fixes the weird characters returned by USPS with the available Rates:
Standard Post&lt;sup&gt;&#174
Priority Mail Express 1-Day&lt;sup&gt;&#8482
