### PR TITLE
Send httpversion 1.1 for PayPal requests

### DIFF
--- a/wpsc-merchants/paypal-express.merchant.php
+++ b/wpsc-merchants/paypal-express.merchant.php
@@ -123,6 +123,7 @@ class wpsc_merchant_paypal_express extends wpsc_merchant {
 		$options = array(
 			'timeout' => 20,
 			'body' => $received_values,
+			'httpversion' => '1.1',
 			'user-agent' => ('WP e-Commerce/'.WPSC_PRESENTABLE_VERSION)
 		);
 
@@ -992,6 +993,7 @@ function paypal_hash_call( $methodName, $nvpStr ) {
 	$options = array(
 		'timeout' => 20,
 		'body' => $nvpreq,
+		'httpversion' => '1.1',
 		'sslverify' => false,
 	);
 

--- a/wpsc-merchants/paypal-pro.merchant.php
+++ b/wpsc-merchants/paypal-pro.merchant.php
@@ -187,6 +187,7 @@ class wpsc_merchant_paypal_pro extends wpsc_merchant {
 		$options = array(
 			'timeout' => 20,
 			'body' => $this->collected_gateway_data,
+			'httpversion' => '1.1',
 			'user-agent' => $this->cart_data['software_name'] . " " . get_bloginfo( 'url' ),
 			'sslverify' => false,
 		);
@@ -260,6 +261,7 @@ class wpsc_merchant_paypal_pro extends wpsc_merchant {
 		$options = array(
 			'timeout'    => 20,
 			'body'       => $received_values,
+			'httpversion' => '1.1',
 			'user-agent' => ('WP e-Commerce/' . WPSC_PRESENTABLE_VERSION)
 		);
 

--- a/wpsc-merchants/paypal-standard.merchant.php
+++ b/wpsc-merchants/paypal-standard.merchant.php
@@ -393,6 +393,7 @@ class wpsc_merchant_paypal_standard extends wpsc_merchant {
 		$options = array(
 			'timeout' => 20,
 			'body' => $received_values,
+			'httpversion' => '1.1',
 			'user-agent' => ( 'WP e-Commerce/' . WPSC_PRESENTABLE_VERSION )
 		);
 


### PR DESCRIPTION
Add httpversion => '1.1' to wp_remote_post calls to PayPal. In theory fixes #611, but untested.
