### PR TITLE
adding action hook to `wpsc_update_featured_products`

### DIFF
--- a/wpsc-admin/display-items.page.php
+++ b/wpsc-admin/display-items.page.php
@@ -542,7 +542,7 @@ function wpsc_update_featured_products() {
 
 	update_option( 'sticky_products', $status );
 
-	do_action( 'wpsc_featured_product_update', $update, $status );
+	do_action( 'wpsc_after_featured_product_update', $update, $status );
 
 	if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 		$json_response = array(


### PR DESCRIPTION
currently, there is no way to do anything while the `wpsc_update_featured_products` is being fired. now there is.
