### PR TITLE
adding action hook to wpsc_update_featured_products

### DIFF
--- a/wpsc-admin/display-items.page.php
+++ b/wpsc-admin/display-items.page.php
@@ -540,7 +540,7 @@ function wpsc_update_featured_products() {
 		$status = array_values( $status );
 	}
 
-	update_option( 'sticky_products', $status );
+	$update	= update_option( 'sticky_products', $status );
 
 	do_action( 'wpsc_after_featured_product_update', $update, $status );
 


### PR DESCRIPTION
currently, there is no way to do anything while the `wpsc_update_featured_products` is being fired. now there is. also changes the update option to a variable to include in said action hook
