### PR TITLE
PR for issue #756 UPS/USPS modules try to calculate rates over and over

### DIFF
--- a/wpsc-shipping/ups_20.php
+++ b/wpsc-shipping/ups_20.php
@@ -12,7 +12,6 @@ class ash_ups {
 	var $is_external = true;
 
 	function ash_ups () {
-		global $wpec_ash;
 		$this->internal_name = "ups";
 		$this->name = _x( "UPS", 'Shipping Module', 'wpsc' );
 		$this->is_external = true;
@@ -21,7 +20,6 @@ class ash_ups {
 		$this->needs_zipcode = true;
 		$this->_setServiceURL();
 		$this->_includeUPSData();
-		$this->shipment = $wpec_ash->get_shipment();
 		return true;
 	}
 
@@ -210,6 +208,9 @@ class ash_ups {
 					<input type="checkbox" id="ups_singular_shipping" name="wpsc_ups_settings[singular_shipping]" value="1" <?php checked( 1, $wpsc_ups_settings['singular_shipping'] ); ?> />
 					<label for="ups_singular_shipping" ><?php _e( 'Singular Shipping', 'wpsc' ); ?> *</label>
 					<p class='description'><?php _e( 'Rate each quantity of items in a cart as its own package using dimensions on product', 'wpsc' ); ?></p>
+					<input type="checkbox" id="ups_intl_rate" name="wpsc_ups_settings[intl_rate]" value="1" <?php checked( 1, $wpsc_ups_settings['intl_rate'] ); ?> />
+					<label for="ups_intl_rate" ><?php _e( 'Disable International Shipping', 'wpsc' ); ?></label>
+					<p class='description'><?php _e( 'No shipping rates will be displayed if the shipment destination country is different than your base country/region.', 'wpsc' ); ?></p>
 				</td>
 			</tr>
 
@@ -345,7 +346,7 @@ class ash_ups {
 
 	private function _build_shipment( &$Shipment, $args ){
 
-		$cart_shipment = apply_filters( 'wpsc_cart_shipment', $this->shipment, $this->name ); //Filter to allow reprocessing shipment packages.
+		$cart_shipment = apply_filters( 'wpsc_the_shipment', $this->shipment, $args ); //Filter to allow reprocessing shipment packages.
 
 		foreach ( $cart_shipment->packages as $package ) {
 			$pack = array(
@@ -718,20 +719,79 @@ class ash_ups {
 	}
 
 	function getQuote() {
-		global $wpdb, $wpec_ash;
-		if ( ! is_object( $wpec_ash ) ) {
-			$wpec_ash = new ASH();
-		}
-
-
+		global $wpdb, $wpec_ash, $wpsc_cart;
 		// Arguments array for various functions to use
 		$args = array();
-		// Final rate table
-		$rate_table = array();
+		
+		$args['dest_ccode'] = wpsc_get_customer_meta( 'shipping_country' );
+		if ( $args['dest_ccode'] == "UK" )
+			// So, UPS is a little off the times
+			$args['dest_ccode'] = "GB";
 		// Get the ups settings from the ups account info page (Shipping tab)
 		$wpsc_ups_settings = get_option( "wpsc_ups_settings", array() );
-		// Get the wordpress shopping cart options
-		$wpsc_options = get_option( "wpsc_options" );
+		//Disable International Shipping. Default: Enabled, as it currently is.
+		$args['intl_rate'] = isset( $wpsc_ups_settings['intl_rate'] ) && ! empty( $wpsc_ups_settings['intl_rate'] ) ? FALSE : TRUE;
+		if ( ! $args['intl_rate'] && $args['dest_ccode'] != get_option( 'base_country' ) )
+			return array();
+		
+		// Destination zip code
+		// If ths zip code is provided via a form post use it!
+		$args['dest_pcode'] = (string) wpsc_get_customer_meta( 'shipping_zip' );
+		if ( isset( $_POST['zipcode'] ) && ( $_POST['zipcode'] != __( "Your Zipcode", 'wpsc' ) && $_POST['zipcode'] != "YOURZIPCODE" ) )
+			$args['dest_pcode'] = esc_attr( $_POST['zipcode'] );
+		if ( in_array( $args['dest_pcode'], array( __( 'Your Zipcode', 'wpsc' ), 'YOURZIPCODE' ) ) )
+			$args['dest_pcode'] = '';
+		if( ! empty ( $args['dest_pcode'] ) )
+			wpsc_update_customer_meta( 'shipping_zip', $args['dest_pcode'] );
+		if ( empty ( $args['dest_pcode'] ) )
+			// We cannot get a quote without a zip code so might as well return!
+			return array();
+		
+		// Get the total weight from the shopping cart
+		$args['weight'] = wpsc_cart_weight_total();
+		if ( empty( $args["weight"] ) )
+			return array();
+		
+		// If the region code is provided via a form post use it!
+		if ( isset( $_POST['region'] ) && ! empty( $_POST['region'] ) ) {
+			$query = $wpdb->prepare( "SELECT `" . WPSC_TABLE_REGION_TAX . "`.* FROM `" . WPSC_TABLE_REGION_TAX . "` WHERE `" . WPSC_TABLE_REGION_TAX . "`.`id` = %d", $_POST['region'] );
+			$dest_region_data = $wpdb->get_results( $query, ARRAY_A );
+			$args['dest_state'] = ( is_array( $dest_region_data ) ) ? $dest_region_data[0]['code'] : "";
+			wpsc_update_customer_meta( 'shipping_state', $args['dest_state'] ); //Unify state meta.
+		} else if ( $dest_state = wpsc_get_customer_meta( 'shipping_state' ) ) {
+			// Well, we have a zip code in the session and no new one provided
+			$args['dest_state'] = $dest_state;
+		} else {
+			$args['dest_state'] = "";
+		}
+		
+		if ( ! is_object( $wpec_ash ) )
+			$wpec_ash = new ASH();
+		
+		$shipping_cache_check['state'] = $args['dest_state']; //The destination is needed for cached shipment check.
+		$shipping_cache_check['country'] = $args['dest_ccode'];
+		$shipping_cache_check['zipcode'] = $args['dest_pcode'];
+		$this->shipment = $wpec_ash->get_shipment();
+		$this->shipment->set_destination( $this->internal_name, $shipping_cache_check ); //Set this shipment's destination.
+		$this->shipment->rates_expire = date('Y-m-d');
+
+		$args["singular_shipping"] = ( array_key_exists( "singular_shipping", $wpsc_ups_settings ) ) ? $wpsc_ups_settings["singular_shipping"]    : "0";
+		if ( $args['weight'] > 150 && ! (boolean) $args["singular_shipping"] ) { // This is where shipping breaks out of UPS if weight is higher than 150 LBS
+				$over_weight_txt = __( 'Your order exceeds the standard shipping weight limit. Please contact us to quote other shipping alternatives.', 'wpsc' );
+				$shipping_quotes[$over_weight_txt] = 0; // yes, a constant.
+				$wpec_ash->cache_results( $this->internal_name, array( $shipping_quotes ), $this->shipment ); //Update shipment cache.
+				return array( $shipping_quotes );
+		}
+		
+		$cache = $wpec_ash->check_cache( $this->internal_name, $this->shipment ); //And now, we're ready to check cache.
+		
+		// We do not want to spam UPS (and slow down our process) if we already
+		// have a shipping quote!
+		if ( count( $cache['rate_table'] ) >= 1 ) //$cache['rate_table'] could be array(0)..
+			return $cache['rate_table'];
+
+		// Final rate table
+		$rate_table = array();
 
 		// API Auth settings //
 		$args['username']          = ( array_key_exists( 'upsaccount',           $wpsc_ups_settings ) ) ? $wpsc_ups_settings['upsusername']          : "";
@@ -740,7 +800,6 @@ class ash_ups {
 		$args['account_number']    = ( array_key_exists( 'upsaccount',           $wpsc_ups_settings ) ) ? $wpsc_ups_settings['upsaccount']           : "";
 		$args['negotiated_rates']  = ( array_key_exists( 'ups_negotiated_rates', $wpsc_ups_settings ) ) ? $wpsc_ups_settings['ups_negotiated_rates'] : "";
 		$args['residential']       = $wpsc_ups_settings['49_residential'];
-		$args["singular_shipping"] = ( array_key_exists( "singular_shipping",    $wpsc_ups_settings ) ) ? $wpsc_ups_settings["singular_shipping"]    : "0";
 		$args['insured_shipment']  = ( array_key_exists( "insured_shipment",     $wpsc_ups_settings ) ) ? $wpsc_ups_settings["insured_shipment"]     : "0";
 		// What kind of pickup service do you use ?
 		$args['DropoffType']       = $wpsc_ups_settings['DropoffType'];
@@ -763,104 +822,37 @@ class ash_ups {
 		$args['shipf_city']  = $args['shipr_city'];
 		$args['shipf_ccode'] = $args['shipr_ccode'];
 		$args['shipf_pcode'] = $args['shipr_pcode'];
-		// Get the total weight from the shopping cart
 		$args['units'] = "LBS";
-		$args['weight'] = wpsc_cart_weight_total();
-		// Destination zip code
-		$args['dest_ccode'] = wpsc_get_customer_meta( 'shipping_country' );
-		if ( $args['dest_ccode'] == "UK" ) {
-			// So, UPS is a little off the times
-			$args['dest_ccode'] = "GB";
-		}
+		$args['shipper']	 = $this->internal_name;
+		$args = apply_filters( 'wpsc_shipment_data', $args, $this->shipment );
 
-		// If ths zip code is provided via a form post use it!
-		$args['dest_pcode'] = (string) wpsc_get_customer_meta( 'shipping_zip' );
-		if ( isset( $_POST['zipcode'] ) && ( $_POST['zipcode'] != __( "Your Zipcode", 'wpsc' ) && $_POST['zipcode'] != "YOURZIPCODE" ) )
-		  $args['dest_pcode'] = esc_attr( $_POST['zipcode'] );
-
-		if ( in_array( $args['dest_pcode'], array( __( 'Your Zipcode', 'wpsc' ), 'YOURZIPCODE' ) ) )
-			$args['dest_pcode'] = '';
-
-		wpsc_update_customer_meta( 'shipping_zip', $args['dest_pcode'] );
-
-		if ( empty ( $args['dest_pcode'] ) ) {
-			// We cannot get a quote without a zip code so might as well return!
-			return array();
-		}
-
-		// If the region code is provided via a form post use it!
-		if ( isset( $_POST['region'] ) && ! empty( $_POST['region'] ) ) {
-			$query = $wpdb->prepare( "SELECT `" . WPSC_TABLE_REGION_TAX . "`.* FROM `" . WPSC_TABLE_REGION_TAX . "` WHERE `" . WPSC_TABLE_REGION_TAX . "`.`id` = %d", $_POST['region'] );
-			$dest_region_data = $wpdb->get_results( $query, ARRAY_A );
-			$args['dest_state'] = ( is_array( $dest_region_data ) ) ? $dest_region_data[0]['code'] : "";
-			wpsc_update_customer_meta( 'ups_state', $args['dest_state'] );
-		} else if ( $dest_state = wpsc_get_customer_meta( 'ups_state' ) ) {
-			// Well, we have a zip code in the session and no new one provided
-			$args['dest_state'] = $dest_state;
+		$args["cart_total"] = $wpsc_cart->calculate_subtotal( true );
+		// Build the XML request
+		$request = $this->_buildRateRequest( $args );
+		// Now that we have the message to send ... Send it!
+		$raw_quote = $this->_makeRateRequest( $request );
+		// Now we have the UPS response .. unfortunately its not ready
+		// to be viewed by normal humans ...
+		$quotes = $this->_parseQuote( $raw_quote );
+		// If we actually have rates back from UPS we can use em!
+		if ( $quotes != false ) {
+			$rate_table = apply_filters( 'wpsc_rates_table', $this->_formatTable( $quotes, $args['currency'] ), $args, $this->shipment );
 		} else {
-			$args['dest_state'] = "";
-		}
-		$shipping_cache_check['package_count'] = $this->shipment->package_count; //Package count is needed for cached shipment check.
-		$shipping_cache_check['destination']['state'] = $args['dest_state']; //The destination is needed for cached shipment check.
-		$shipping_cache_check['destination']['country'] = $args['dest_ccode'];
-		$shipping_cache_check['destination']['zipcode'] = $args['dest_pcode'];
-		$shipping_cache_check['total_weight'] = $args['weight'];
-		$shipping_cache_check['rates_expire'] = date('Y-m-d');
-		$this->shipment->rates_expire = date('Y-m-d');
-		$this->shipment->set_destination($this->internal_name,$shipping_cache_check['destination']); //Set this shipment's destination.
- 		$session_cache_check = $wpec_ash->check_cache( $this->internal_name, $this->shipment ); //Now, we're ready to check cache.
-		if ( ! is_array( $session_cache_check ) ) {
-			$session_cache_check = array();
-		}
-		$session_cache = $session_cache_check;
-		if ( ! is_array( $session_cache ) ) {
-			$session_cache = array();
-		} else
-			$session_cache_check = $session_cache_check['shipment'];
-		if ( ! (boolean) $args["singular_shipping"] ) {
-			// This is where shipping breaks out of UPS if weight is higher than 150 LBS
-			if ( $args['weight'] > 150 ) {
-					$this->shipment->set_destination($this->internal_name,$shipping_cache_check['destination']);
-					$this->shipment->rates_expire = date('Y-m-d');
-					$shipping_quotes[ TXT_WPSC_OVER_UPS_WEIGHT ] = 0; // yes, a constant.
-					$wpec_ash->cache_results($this->internal_name,array($shipping_quotes),$this->shipment); //Update shipment cache.
-					return array( $shipping_quotes );
+			if ( $wpsc_ups_settings['upsenvironment'] == '1' ) {
+				echo "<strong>:: GetQuote ::DEBUG OUTPUT::</strong><br />";
+				echo "Arguments sent to UPS";
+				print_r( $args );
+				echo "<hr />";
+				print $request;
+				echo "<hr />";
+				echo "Response from UPS";
+				echo $raw_quote;
+				echo "</strong>:: GetQuote ::End DEBUG OUTPUT::";
 			}
 		}
-		// We do not want to spam UPS (and slow down our process) if we already
-		// have a shipping quote!
-		if ( ( $session_cache_check === $shipping_cache_check ) && ( count( $session_cache['rate_table']) >= 1 ) ) { //'rate_table' could be array(0).
-			$rate_table = $session_cache['rate_table'];
-			return $rate_table;
-		} else {
-			global $wpsc_cart;
-			$args["cart_total"] = $wpsc_cart->calculate_subtotal( true );
-			// Build the XML request
-			$request = $this->_buildRateRequest( $args );
-			// Now that we have the message to send ... Send it!
-			$raw_quote = $this->_makeRateRequest( $request );
-			// Now we have the UPS response .. unfortunately its not ready
-			// to be viewed by normal humans ...
-			$quotes = $this->_parseQuote( $raw_quote );
-			// If we actually have rates back from UPS we can use em!
-			if ( $quotes != false ) {
-				$rate_table = $this->_formatTable( $quotes, $args['currency'] );
-			} else {
-				if ( $wpsc_ups_settings['upsenvironment'] == '1' ) {
-					echo "<strong>:: GetQuote ::DEBUG OUTPUT::</strong><br />";
-					echo "Arguments sent to UPS";
-					print_r( $args );
-					echo "<hr />";
-					print $request;
-					echo "<hr />";
-					echo "Response from UPS";
-					echo $raw_quote;
-					echo "</strong>:: GetQuote ::End DEBUG OUTPUT::";
-				}
-			}
-		}
-		$this->shipment->rates_expire = date('Y-m-d'); //Refresh rates once a day.
-		$this->shipment->set_destination($this->internal_name,$shipping_cache_check['destination']); //Set destination before caching rates.
+		//Avoid trying getting rates again and again when the stored zipcode is incorrect.
+		if( count( $rate_table ) == 0 )
+			wpsc_update_customer_meta( 'shipping_zip', '' );
 		$wpec_ash->cache_results(
 			$this->internal_name,
 			$rate_table,

--- a/wpsc-shipping/usps_20.php
+++ b/wpsc-shipping/usps_20.php
@@ -215,6 +215,11 @@ class ash_usps {
 					<?php _e( 'Advanced Rates', 'wpsc' ); ?>
 				</label>
 				<p class='description'><?php _e( 'This setting will provide rates based on the dimensions from each item in your cart', 'wpsc' ); ?></p>
+				<label>
+					<input type='checkbox' <?php checked( $settings['intl_rate'], 1 ); ?> name='wpec_usps[intl_rate]' value='1' />
+					<?php _e( 'Disable International Shipping', 'wpsc' ); ?>
+				</label>
+				<p class='description'><?php _e( 'No shipping rates will be displayed if the shipment destination country is different than your base country/region.', 'wpsc' ); ?></p>
 			</td>
 		</tr>
 
@@ -724,9 +729,8 @@ class ash_usps {
 	function _quote_advanced( array $data ) {
 		global $wpec_ash_xml;
 
-		$rate_tables   = array();
-		$cart_shipment = apply_filters( 'wpsc_cart_shipment', $this->shipment, $this->name ); //Filter to allow reprocesing the shipment before is quoted.
-
+		$rate_tables = array();
+		$cart_shipment = apply_filters( 'wpsc_the_shipment', $this->shipment, $data ); //Filter to allow reprocesing the shipment before is quoted.
 		foreach ( $cart_shipment->packages as $package ) {
 			$temp_data = $data;
 			$request = $this->_build_request( $temp_data );
@@ -762,7 +766,7 @@ class ash_usps {
 	function _quote_intl( array $data ) {
 		global $wpec_ash_xml;
 		$rate_tables = array();
-		$cart_shipment = apply_filters('wpsc_the_shipment',$this->name,$this->shipment); //Filter to allow reprocesing the shipment before is quoted.
+		$cart_shipment = apply_filters( 'wpsc_the_shipment', $this->shipment, $data ); //Filter to allow reprocesing the shipment before is quoted.
 		foreach ( $cart_shipment->packages as $package ) {
 			$temp_data = $data;
 			$request = $this->_build_request( $temp_data );
@@ -884,72 +888,74 @@ class ash_usps {
 	 */
 	function getQuote() {
 		global $wpdb, $wpec_ash, $wpec_ash_tools;
-		if ( ! is_object( $wpec_ash ) ) {
-			$wpec_ash = new ASH();
-		}
-		if ( ! is_object( $wpec_ash_tools ) ) {
-			$wpec_ash_tools = new ASHTools();
-		}
 		$data = array();
-		$this->shipment = $wpec_ash->get_shipment();
 		//************** These values are common to all entry points **************
-		//*** Grab Total Weight from the shipment object for simple shipping
-		$data["weight"] = wpsc_cart_weight_total();
-		if ( empty( $data["weight"] ) ) {
-			return array();
-		}
-
 		//*** User/Customer Entered Values ***\\
+		//*** Set up the destination country ***\
+		$data["dest_country"] = wpsc_get_customer_meta( 'shipping_country' );
+		$settings = get_option( 'wpec_usps' );
+		//Disable International Shipping. Default: Enabled as it currently is.
+		$data['intl_rate'] = isset( $settings['intl_rate'] ) && ! empty( $settings['intl_rate'] ) ? FALSE : TRUE;
+		if( ! $data['intl_rate'] && $data['dest_country'] != get_option( 'base_country' ) )
+			return array();
+
 		// If ths zip code is provided via a form post use it!
 		$data["dest_zipcode"] = (string) wpsc_get_customer_meta( 'shipping_zip' );
 		if ( isset( $_POST['zipcode'] ) && ( $_POST['zipcode'] != __( "Your Zipcode", 'wpsc' ) && $_POST['zipcode'] != "YOURZIPCODE" ) )
 			$data["dest_zipcode"] = esc_attr( $_POST['zipcode'] );
 		if ( in_array( $data["dest_zipcode"], array( __( 'Your Zipcode', 'wpsc' ), 'YOURZIPCODE' ) ) )
 			$data["dest_zipcode"] = '';
-		wpsc_update_customer_meta( 'shipping_zip', $data["dest_zipcode"] );
-		if ( empty ( $data["dest_zipcode"] ) ) {
+		if( ! empty( $data["dest_zipcode"] ) )
+			wpsc_update_customer_meta( 'shipping_zip', $data["dest_zipcode"] );
+		if ( empty ( $data["dest_zipcode"] ) )
 			// We cannot get a quote without a zip code so might as well return!
 			return array();
-		}
+		//*** Grab Total Weight from the shipment object for simple shipping
+		$data["weight"] = wpsc_cart_weight_total();
+		if ( empty( $data["weight"] ) )
+			return array();
 
 		// If the region code is provided via a form post use it!
 		if ( isset( $_POST['region'] ) && ! empty( $_POST['region'] ) ) {
 			$query = $wpdb->prepare( "SELECT `" . WPSC_TABLE_REGION_TAX . "`.* FROM `" . WPSC_TABLE_REGION_TAX . "` WHERE `" . WPSC_TABLE_REGION_TAX . "`.`id` = %d", $_POST['region'] );
 			$dest_region_data = $wpdb->get_results( $query, ARRAY_A );
 			$data['dest_state'] = ( is_array( $dest_region_data ) ) ? $dest_region_data[0]['code'] : "";
-			wpsc_update_customer_meta( 'usps_state', $data['dest_state'] );
-		} else if ( $dest_state = wpsc_get_customer_meta( 'usps_state' ) ) {
+			wpsc_update_customer_meta( 'shipping_state', $data['dest_state'] ); //Unify state meta.
+		} else if ( $dest_state = wpsc_get_customer_meta( 'shipping_state' ) ) {
 			// Well, we have a zip code in the session and no new one provided
 			$data['dest_state'] = $dest_state;
 		} else {
 			$data['dest_state'] = "";
 		}
+		if ( ! is_object( $wpec_ash_tools ) )
+			$wpec_ash_tools = new ASHTools();
 
-		//*** Set up the destination country ***\
-		$data["dest_country"] = wpsc_get_customer_meta( 'shipping_country' );
 		$data["dest_country"] = $wpec_ash_tools->get_full_country( $data["dest_country"] );
 		$data["dest_country"] = $this->_update_country( $data["dest_country"] );
 
+		if ( ! is_object( $wpec_ash ) )
+			$wpec_ash = new ASH();
 		$shipping_cache_check['state'] = $data['dest_state'];
 		$shipping_cache_check['country'] = $data['dest_country'];
 		$shipping_cache_check['zipcode'] = $data["dest_zipcode"];
+		$this->shipment = $wpec_ash->get_shipment();
 		$this->shipment->set_destination( $this->internal_name, $shipping_cache_check );
-
-		$settings = get_option( "wpec_usps" );
-		$data["adv_rate"] = (!empty($settings["adv_rate"])) ? $settings["adv_rate"] : FALSE; // Use advanced shipping for Domestic Rates ? Not available
 		$this->shipment->rates_expire = date('Y-m-d'); //Date will be checked against the cached date.
-		if ( $data["weight"] > 70 && ! $data["adv_rate"] ) { //Yes, USPS has a weight limit too: https://www.usps.com/send/can-you-mail-it.htm?#3.
-			$shipping_quotes[TXT_WPSC_OVER_UPS_WEIGHT]=0; //FIXME Remove UPS and 150lb from this message, and it can be used here too. Temporary fix.
+
+		$data["adv_rate"] = (!empty($settings["adv_rate"])) ? $settings["adv_rate"] : FALSE; // Use advanced shipping for Domestic Rates ? Not available
+		if ( $data["weight"] > 70 && ! (boolean) $data["adv_rate"] ) { //USPS has a weight limit: https://www.usps.com/send/can-you-mail-it.htm?#3.
+			$over_weight_txt = __('Your order exceeds the standard shipping weight limit. Please contact us to quote other shipping alternatives.','wpsc');
+			$shipping_quotes[$over_weight_txt] = 0; // yes, a constant.
 			$wpec_ash->cache_results( $this->internal_name, array($shipping_quotes), $this->shipment );
 			return array($shipping_quotes);
 		}
 
 		// Check to see if the cached shipment is still accurate, if not we need new rate
 		$cache = $wpec_ash->check_cache( $this->internal_name, $this->shipment );
-
-		if ( count($cache["rate_table"]) >= 1 ) { //$cache['rate_table'] could be array(0).
+		// We do not want to spam USPS (and slow down our process) if we already
+		// have a shipping quote!
+		if ( count($cache["rate_table"] ) >= 1 ) //$cache['rate_table'] could be array(0).
 			return $cache["rate_table"];
-		}
 
 		//*** WPEC Configuration values ***\\
 		$this->use_test_env   = ( ! isset( $settings["test_server"] ) ) ? false : ( bool ) $settings['test_server'];
@@ -958,8 +964,13 @@ class ash_usps {
 		$data["base_zipcode"] = get_option( "base_zipcode" );
 		$data["services"]     = ( ! empty( $settings["services"] ) ) ? $settings["services"] : array( "PRIORITY", "EXPRESS", "FIRST CLASS" );
 		$data["user_id"]      = $settings["id"];
+		$data['shipper']      = $this->internal_name;
+		$data = apply_filters( 'wpsc_shipment_data', $data, $this->shipment );
 		//************ GET THE RATE ************\\
-		$rate_table           = $this->_run_quote( $data );
+		$rate_table = apply_filters( 'wpsc_rates_table', $this->_run_quote( $data ), $data, $this->shipment );
+		//Avoid trying getting rates again and again when the stored zipcode is incorrect.
+		if( count( $rate_table ) == 0 )
+			wpsc_update_customer_meta( 'shipping_zip', '' );
 		//************ CACHE the Results ************\\
 		$wpec_ash->cache_results( $this->internal_name, $rate_table, $this->shipment );
 		return $rate_table;


### PR DESCRIPTION
Here are the modifications indicated in issue #756:

a) Modified the TXT_WPSC_OVER_UPS_WEIGHT constant to
TXT_WPSC_OVER_WEIGHT in wpsc-languages/EN_en.php. The text now reads:
"Your order exceeds the standard shipping weight limit. Please contact
us to quote other shipping alternatives.". This text is now used in
both USPS and UPS weight limit checks.

b) Added a checkbox to provide the ability of disabling international
shipping, for those who don't want to offer it. The standard behavior
is not affected (Enabled). This is part of the getQuote initial
conditions check.

c) The UPS module getQuote filter now matches the more efficient USPS
rates initial conditions check. The data checked is the destination
country, zip code, and shipment weight. Then there's a shipper weight
limit check if you want the whole shipment to be rated as one envelope.
If any of these data checks fail, bail. If these datas checks are ok,
check cache and return the rate table if found. Else, continue the rate
table request process.

d) The UPS cache check process now matches the USPS cache check
process, which uses less variables.

e) Moved UPS's shipment being assigned at the constructor to getQuote
(right after the bail checks). This avoids the shipment being assigned
to the ash_ups class every time this class is instantiated during each
session, matching the USPS module behavior.

f) I removed some redundant variable assignments done at the end of
getQuote (rates_expire, set_destination). These values have already
being assigned before the cache check.

g) I'm assigning the shipper's internal name to the $args (UPS) or
$data (USPS) arrays, so the wpsc_cart_shipment hook $this->name
parameter is now changed to $args or $data, depending on the shipper
module. I'm using this hook to apply a partitioning problem/bin packing
algorithm to reduce the package quantity, and therefore reduce the
shipping cost. It's a new hook, so at this point no one else should be
affected with this modification.

h) I'm adding a new hook called wpsc_shipment_data, after setting the
quote request data and before requesting the quote. I'm using this hook
to check if the shipment could be rated as shipped as an envelope
(movies), instead of packages, to modify on the shipment type data flag.

i) I'm adding another hook called wpsc_rates_table right before
returning the rates table. I use this to add packaging costs to the
rates, based on the shipment contents.

If you have any questions or comments, please don't hesitate to ask.
