### PR TITLE
Fix SQL errors when searching sales log page

### DIFF
--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -166,6 +166,7 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		$total_sql = "
 			SELECT SUM(totalprice)
 			FROM " . WPSC_TABLE_PURCHASE_LOGS . " AS p
+			{$this->joins}
 			WHERE {$total_where}
 		";
 
@@ -238,6 +239,7 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		$sql = "
 			SELECT DISTINCT YEAR(FROM_UNIXTIME(date)) AS year, MONTH(FROM_UNIXTIME(date)) AS month
 			FROM " . WPSC_TABLE_PURCHASE_LOGS . " AS p
+			{$this->joins}
 			WHERE {$this->where_no_filter}
 			ORDER BY date DESC
 		";


### PR DESCRIPTION
The SQL to generate the sales total for the filtered list, and the months for the filter drop-down use the WHERE conditions from the generated query, however they don't use the relevant JOINS leading them to try and restrict the query on fields which don't exist. This adds the joins to the query, which means that searching the sales log no longer WSODs. Sales totals, and month filters appear to be correct on my test site. 

Fixes #510
