### PR TITLE
Grid view not working on products page

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/page.php
+++ b/wpsc-components/theme-engine-v1/helpers/page.php
@@ -633,12 +633,8 @@ function wpsc_products_page( $content = '' ) {
 		$GLOBALS['nzshpcrt_activateshpcrt'] = true;
 
 		// get the display type for the productspage
-		$display_type = wpsc_check_display_type();
-		if ( get_option( 'show_search' ) && get_option( 'show_advanced_search' ) ) {
-			$saved_display = wpsc_get_customer_meta( 'display_type' );
-			if ( ! empty( $saved_display ) )
-				$display_type = $saved_display;
-		}
+		$saved_display = wpsc_get_customer_meta( 'display_type' );
+		$display_type  = ! empty( $saved_display ) ? $saved_display : wpsc_check_display_type();
 
 		ob_start();
 		wpsc_include_products_page_template($display_type);


### PR DESCRIPTION
The grid view has stopped working on the products page. The Grid / List icon still works fine, but the display is always in list view. The logic that determines the display type is now wrapped in a check for both 'show_search' and 'show_advanced_search', and in my case neither of these has been set. Reverting this code fixed the problem for me.
