### PR TITLE
Give the option to the theme to change the packing slip 

### DIFF
--- a/wpsc-admin/display-sales-logs.php
+++ b/wpsc-admin/display-sales-logs.php
@@ -301,11 +301,11 @@ class WPSC_Purchase_Log_Page {
 
 		register_column_headers( 'wpsc_purchase_log_item_details', $columns );
 
-
-		if ( file_exists(get_stylesheet_directory() . '/packing-slip.php' ) )
-			include( get_stylesheet_directory() . '/packing-slip.php' );
-		else
+		if ( file_exists( get_stylesheet_directory() . '/wpsc-packing-slip.php' ) ) {
+			include( get_stylesheet_directory() . '/wpsc-packing-slip.php' );
+		} else {
 			include( 'includes/purchase-logs-page/packing-slip.php' );
+		}
 
 		exit;
 	}


### PR DESCRIPTION
Option to theme the packing slip that is displayed, and is often printed and included with shipped items.

Resolves issue #811
