### PR TITLE
PHP Runtime warning

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -1066,7 +1066,7 @@ function wpsc_dashboard_4months_widget() {
 	$timeranges[2]["start"] = mktime( 0, 0, 0, $this_month - 1, 1, $this_year );
 	$timeranges[2]["end"] = mktime( 0, 0, 0, $this_month, 1, $this_year );
 	$timeranges[3]["start"] = mktime( 0, 0, 0, $this_month, 1, $this_year );
-	$timeranges[3]["end"] = mktime();
+	$timeranges[3]["end"] = time(); // using mktime here can generate a php runtime warning
 
 	$prod_data = array( );
 	foreach ( (array)$products as $product ) { //run through products and get each product income amounts and name


### PR DESCRIPTION
eliminate possibility of php runtime warning about using mktime() without parameters instead of time()

fixes issue #820
