### PR TITLE
Add a filter to allow custom information  on packing slips or other sales documents/displays

### DIFF
--- a/wpsc-admin/display-sales-logs.php
+++ b/wpsc-admin/display-sales-logs.php
@@ -240,7 +240,7 @@ class WPSC_Purchase_Log_Page {
 			<td class="amount"><?php echo wpsc_currency_display( wpsc_purchaselog_details_total() ); ?></td> <!-- TOTAL! -->
 		</tr>
 		<?php
-		do_action( 'wpsc_additional_sales_item_info' );
+		do_action( 'wpsc_additional_sales_item_info', wpsc_purchaselog_details_id() );
 		endwhile;
 	}
 


### PR DESCRIPTION
This custom information can come from places like custom cart meta or custom sales meta, customer profiles or anywhere else.

Resolved Issue #822
