### PR TITLE
Start product query fixes

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/query.php
+++ b/wpsc-components/theme-engine-v1/helpers/query.php
@@ -168,7 +168,7 @@ function _wpsc_pre_get_posts_reset_taxonomy_globals( $query ) {
  * wpsc_start_the_query
  */
 function wpsc_start_the_query() {
-	global $wp_query, $wpsc_query, $wpsc_query_vars;
+	global $wpsc_page_titles, $wp_query, $wpsc_query, $wpsc_query_vars;
 
 	$is_404 = false;
 	if ( null == $wpsc_query ) {


### PR DESCRIPTION
removed unreferenced global.
removed call to get_post_type_object() whose return value was never used.
query will retrieve post types of 'wpsc-product' by default, consistent with other similar queries.
query post type is overridable using a new filter that is similar to the other filters on the same query.

Resolves issue #828
