### PR TITLE
Customer cookie should be set without https

### DIFF
--- a/wpsc-includes/customer.php
+++ b/wpsc-includes/customer.php
@@ -17,13 +17,15 @@ add_filter( 'editable_roles'             , '_wpsc_filter_editable_roles'        
  * @param  int   $expire  Expiration timestamp
  */
 function _wpsc_set_customer_cookie( $cookie, $expire ) {
-	$secure = is_ssl();
+	// we set the cookie to non-secure so that it is available to shoppers on both secure an non-secure pages
+	$secure = false;
 	setcookie( WPSC_CUSTOMER_COOKIE, $cookie, $expire, WPSC_CUSTOMER_COOKIE_PATH, COOKIE_DOMAIN, $secure, true );
 
-	if ( $expire < time() )
+	if ( $expire < time() ) {
 		unset( $_COOKIE[WPSC_CUSTOMER_COOKIE] );
-	else
+	} else {
 		$_COOKIE[WPSC_CUSTOMER_COOKIE] = $cookie;
+	}
 }
 
 /**


### PR DESCRIPTION
So that the cookie is available on sites where some pages are HTTP and others are HTTPS.

REsolves #837
