### PR TITLE
Validate Customer Cookie Instead of Just Parsing

### DIFF
--- a/wpsc-includes/customer.php
+++ b/wpsc-includes/customer.php
@@ -177,15 +177,18 @@ function _wpsc_validate_customer_cookie() {
 function wpsc_get_current_customer_id() {
 	$id = apply_filters( 'wpsc_get_current_customer_id', null );
 
-	if ( ! empty( $id ) )
+	if ( ! empty( $id ) ) {
 		return $id;
+	}
 
 	// if the user is logged in we use the user id
 	if ( is_user_logged_in() ) {
 		return get_current_user_id();
 	} elseif ( isset( $_COOKIE[WPSC_CUSTOMER_COOKIE] ) ) {
-		list( $id, $expire, $hash ) = explode( '|', $_COOKIE[WPSC_CUSTOMER_COOKIE] );
-		return $id;
+		$id = wpsc_validate_customer_cookie();
+		if ( $id !== false ) {
+			return $id;
+		}
 	}
 
 	return _wpsc_create_customer_id();


### PR DESCRIPTION
Instead of assuming the cookie value is valid if set use the exiting routine to parse and validate it.
There seems to be a case where outside code could call wpsc_get_current_customer_id() before the cookie
is validated, this eliminates the possibility that the cookie could be invalidated and cleared after
being used.

Fixes issue #839
