### PR TITLE
Marketplace minor menu display fix

### DIFF
--- a/wpsc-components/marketplace-core-v1/static/admin.css
+++ b/wpsc-components/marketplace-core-v1/static/admin.css
@@ -127,7 +127,6 @@
 	margin-top: 0;
 	height: auto;
 	position: relative;
-	bottom: 18px;
 }
 .grid-view {
 	margin: 0 0 15px;


### PR DESCRIPTION
Before you had to hover the mouse a bit over the text for it to become clickable
