### PR TITLE
Packing Slip filter

### DIFF
--- a/wpsc-admin/display-sales-logs.php
+++ b/wpsc-admin/display-sales-logs.php
@@ -308,7 +308,7 @@ class WPSC_Purchase_Log_Page {
 			$packing_slip_file = 'includes/purchase-logs-page/packing-slip.php';
 		}
 
-		$packing_slip_file - apply_filters( 'wpsc_packing_packing_slip_html_path', $packing_slip_file );
+		$packing_slip_file - apply_filters( 'wpsc_packing_packing_slip_path', $packing_slip_file );
 
 		include( $packing_slip_file );
 


### PR DESCRIPTION
Add filter to override packing slip file path in function controller_packing_slip. Filter will make it possible for plugins to add to packing slip, for example adding pre-printed shipping labels.

Also, fixed a couple of whitespace issues in function controller_packing_slip

PR for Issue #858
