### PR TITLE
Add 'wpsc_gateway_name' filter.

### DIFF
--- a/wpsc-components/merchant-core-v2/helpers/gateways.php
+++ b/wpsc-components/merchant-core-v2/helpers/gateways.php
@@ -67,7 +67,8 @@ function wpsc_gateway_image_url(){
 
 /**
  * Return the current gateway's name.
- * @return string The current gateway's name.
+ * 
+ * @return  string  The current gateway's name.
  */
 function wpsc_gateway_name() {
 	global $wpsc_gateway;
@@ -75,36 +76,55 @@ function wpsc_gateway_name() {
 
 	$payment_gateway_names = get_option( 'payment_gateway_names' );
 
-	if ( isset( $payment_gateway_names[$wpsc_gateway->gateway['internalname']] ) && ( $payment_gateway_names[$wpsc_gateway->gateway['internalname']] != '' || wpsc_show_gateway_image() ) ) {
-		$display_name = $payment_gateway_names[$wpsc_gateway->gateway['internalname']];
-	} elseif ( isset( $wpsc_gateway->gateway['payment_type'] ) ) {
-		switch ( $wpsc_gateway->gateway['payment_type'] ) {
-			case "paypal":
-			case "paypal_pro":
-			case "wpsc_merchant_paypal_pro";
+	// Use gateway internal name if set
+	if ( isset( $payment_gateway_names[ $wpsc_gateway->gateway['internalname'] ] ) && ( $payment_gateway_names[ $wpsc_gateway->gateway['internalname'] ] != '' || wpsc_show_gateway_image() ) ) {
+		$display_name = $payment_gateway_names[ $wpsc_gateway->gateway['internalname'] ];
+	}
+
+	$display_name = apply_filters( 'wpsc_gateway_name', $display_name, $wpsc_gateway->gateway );
+
+	// If no display name or image, use default
+	if ( $display_name == '' && ! wpsc_show_gateway_image() ) {
+		$display_name = __( 'Credit Card', 'wpsc' );
+	}
+
+	return $display_name;
+}
+
+/**
+ * WPSC Default Gateway Name Filter
+ *
+ * @param   string  $display_name  Gateway name.
+ * @param   array   $gateway       Gateway details.
+ * @return  string                 Filtered gateway name.
+ */
+function _wpsc_gateway_name_filter( $display_name, $gateway ) {
+	if ( empty( $display_name ) && isset( $gateway['payment_type'] ) && ! wpsc_show_gateway_image() ) {
+		switch ( $gateway['payment_type'] ) {
+			case 'paypal':
+			case 'paypal_pro':
+			case 'wpsc_merchant_paypal_pro';
 				$display_name = __( 'PayPal', 'wpsc' );
 				break;
 
-			case "manual_payment":
+			case 'manual_payment':
 				$display_name =  __( 'Manual Payment', 'wpsc' );
 				break;
 
-			case "google_checkout":
+			case 'google_checkout':
 				$display_name = __( 'Google Wallet', 'wpsc' );
 				break;
 
-			case "credit_card":
+			case 'credit_card':
 			default:
 				$display_name = __( 'Credit Card', 'wpsc' );
 				break;
 		}
 	}
-	if ( $display_name == '' && !wpsc_show_gateway_image() ) {
-		$display_name = __( 'Credit Card', 'wpsc' );
-	}
 	return $display_name;
 }
 
+add_filter( 'wpsc_gateway_name', '_wpsc_gateway_name_filter', 10, 2 );
 
 /**
  * Return the current gateway's internal name


### PR DESCRIPTION
For issue #673

Introduces a 'wpsc_gateway_name' filter so the display name of gateways can be customised on checkout page.

Gateways _should_ have an 'internalname' defined.
I have used an implementation of the filter to recreate the current switch statement functionality, although I think this is just for legacy reasons?

I need a gateway itself could use this filter to change it's display text.
