### PR TITLE
Customer/ Visitor Meta Bug changes/fixes

### DIFF
--- a/wpsc-includes/customer-private.php
+++ b/wpsc-includes/customer-private.php
@@ -79,7 +79,7 @@ function _wpsc_set_customer_cookie( $cookie, $expire ) {
 
 	// only set the cookie if headers have not been sent, if headers have been sent
 	if ( ! headers_sent() ) {
-		setcookie( WPSC_CUSTOMER_COOKIE, $cookie, $expire, WPSC_CUSTOMER_COOKIE_PATH, COOKIE_DOMAIN, false, true );
+		setcookie( WPSC_CUSTOMER_COOKIE, $cookie, $expire, WPSC_CUSTOMER_COOKIE_PATH, COOKIE_DOMAIN, false, false );
 	}
 
 	if ( $expire < time() ) {


### PR DESCRIPTION
- Don't set WPEC customer cookie in HTTP only mode, our javascript will not be able to see the customer id
