### PR TITLE
Enhancements and Fixes From Visitor Meta Testing 

### DIFF
--- a/wpsc-includes/wpsc-meta-customer.php
+++ b/wpsc-includes/wpsc-meta-customer.php
@@ -41,7 +41,7 @@ function wpsc_delete_customer_meta( $key, $id = false ) {
 		$id = wpsc_get_current_customer_id();
 	}
 
-	$success = wpsc_delete_visitor_meta( $id, _wpsc_get_customer_meta_key( $key ) );
+	$success = wpsc_delete_visitor_meta( $id, $key );
 
 	// notification after any meta item has been deleted
 	if ( $success && has_action( $action = 'wpsc_deleted_customer_meta' ) ) {
@@ -75,7 +75,7 @@ function wpsc_update_customer_meta( $key, $value, $id = false ) {
 		$id = wpsc_get_current_customer_id();
 	}
 
-	$result = wpsc_update_visitor_meta( $id, _wpsc_get_customer_meta_key( $key ), $value );
+	$result = wpsc_update_visitor_meta( $id, $key, $value );
 
 	// notification after any meta item has been updated
 	if ( $result && has_action( $action = 'wpsc_updated_customer_meta' ) ) {
@@ -136,7 +136,7 @@ function wpsc_get_customer_meta( $key = '', $id = false ) {
 		$id = wpsc_get_current_customer_id();
 	}
 
-	$meta_value = wpsc_get_visitor_meta( $id, _wpsc_get_customer_meta_key( $key ), true );
+	$meta_value = wpsc_get_visitor_meta( $id, $key, true );
 
 	// notification when any meta item is retrieved
 	if ( has_filter( $filter = 'wpsc_got_customer_meta' ) ) {

--- a/wpsc-includes/wpsc-visitor.class.php
+++ b/wpsc-includes/wpsc-visitor.class.php
@@ -87,6 +87,10 @@ class WPSC_Visitor {
 	 * @since 3.8.14
 	 */
 	function set( $attribute, $value ) {
+
+		$property_name = '_' . $attribute;
+		$this->$property_name = $value;
+
 		if ( in_array( $attribute, $visitor_table_attribute_list ) ) {
 			// test if change of the attribute is permitted
 			if ( $visitor_table_attribute_list( $attribute ) ) {
@@ -124,6 +128,28 @@ class WPSC_Visitor {
 													'expires'     => false,
 													'created'     => false,
 											);
+
+
+	// helper function for well known variables
+	function id() {
+		return $this->_id;
+	}
+
+	function user_id() {
+		return $this->_user_id;
+	}
+
+	function last_active() {
+		return $this->_last_active;
+	}
+
+	function created() {
+		return $this->_created;
+	}
+
+	function cart() {
+		return $this->_cart;
+	}
 
 
 	//////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- No longer need to prefix customer meta because we aren't storing it in the wordpress tables
