### PR TITLE
Cart Quantity Error on Uninitialized Cart

### DIFF
--- a/wpsc-includes/cart.class.php
+++ b/wpsc-includes/cart.class.php
@@ -320,9 +320,24 @@ function wpsc_update_shipping_multiple_methods(){
 }
 
 function wpsc_get_remaining_quantity( $product_id, $variations = array(), $quantity = 1 ) {
-  global $wpsc_cart;
 
-	return $wpsc_cart->get_remaining_quantity( $product_id, $variations, $quantity );
+	global $wpdb;
+
+	$stock = get_post_meta($product_id, '_wpsc_stock', true);
+	$stock = apply_filters('wpsc_product_stock', $stock, $product_id);
+	$output = 0;
+
+	// check to see if the product uses stock
+	if (is_numeric( $stock ) ) {
+		$priceandstock_id = 0;
+
+		if ( $stock > 0 ) {
+			$claimed_stock = $wpdb->get_var( "SELECT SUM(`stock_claimed`) FROM `" . WPSC_TABLE_CLAIMED_STOCK . "` WHERE `product_id` IN('$product_id') AND `variation_stock_id` IN('$priceandstock_id')" );
+			$output = $stock - $claimed_stock;
+		}
+	}
+
+	return $output;
 }
 
 /**
@@ -766,24 +781,8 @@ class wpsc_cart {
     * @param array  variations on the product
     * @return boolean true on sucess, false on failure
    */
-	function get_remaining_quantity($product_id, $variations = array(), $quantity = 1) {
-		global $wpdb;
-
-		$stock = get_post_meta($product_id, '_wpsc_stock', true);
-		$stock = apply_filters('wpsc_product_stock', $stock, $product_id);
-		$output = 0;
-
-		// check to see if the product uses stock
-		if (is_numeric( $stock ) ) {
-			$priceandstock_id = 0;
-
-			if ( $stock > 0 ) {
-				$claimed_stock = $wpdb->get_var( "SELECT SUM(`stock_claimed`) FROM `" . WPSC_TABLE_CLAIMED_STOCK . "` WHERE `product_id` IN('$product_id') AND `variation_stock_id` IN('$priceandstock_id')" );
-				$output = $stock - $claimed_stock;
-			}
-		}
-
-		return $output;
+	function get_remaining_quantity( $product_id, $variations = array(), $quantity = 1 ) {
+		return wpsc_get_remaining_quantity( $product_id, $variations, $quantity );
 	}
 
 


### PR DESCRIPTION
- Moved remaining product quantity logic from class to the existing standalone function. Class function now calls standalone function rather than the other way around.
- Global cart was being accessed to in the standalone function even though it may not have been initialized.
