### PR TITLE
Error notices on latest master and UPS

### DIFF
--- a/wpsc-shipping/ups_20.php
+++ b/wpsc-shipping/ups_20.php
@@ -721,7 +721,7 @@ class ash_ups {
 	}
 
 	function getQuote() {
-		global $wpdb, $wpec_ash, $wpsc_cart;
+		global $wpdb, $wpec_ash, $wpsc_cart, $wpec_ash_tools;
 		// Arguments array for various functions to use
 		$args = array();
 		


### PR DESCRIPTION
`Notice: Undefined variable: wpec_ash_tools in D:\wamp\www\latestwpec\wp-content\plugins\WP-e-Commerce-master\wpsc-shipping\ups_20.php on line 752`

Adding the $wpec_ash_tools to the globals seems to fix it. I looked at USPS and usps has it in the globals so i based my change on that
