### PR TITLE
Get customer meta AJAX should not return error on empty keta keys

### DIFF
--- a/wpsc-includes/customer-ajax.php
+++ b/wpsc-includes/customer-ajax.php
@@ -60,17 +60,10 @@ if ( _wpsc_doing_customer_meta_ajax() ) {
 		}
 
 		$response = array( 'request' => $_REQUEST );
+		$response = _wpsc_add_customer_meta_to_response( $response, $meta );
 
-		if ( ! empty( $meta ) ) {
-			$response = _wpsc_add_customer_meta_to_response( $response, $meta );
-			$response['type'] = __( 'success', 'wpsc' );
-			$response['error'] = '';
-		} else {
-			$response['value'] = '';
-			$response['type']  = __( 'error', 'wpsc' );
-			$response['error'] = __( 'no meta key', 'wpsc' );
-			_wpsc_doing_it_wrong( __FUNCTION__, __( 'missing meta key', 'wpsc' ), '3.8.14' );
-		}
+		$response['type'] = __( 'success', 'wpsc' );
+		$response['error'] = '';
 
 		wp_send_json_success( $response );
 		die();


### PR DESCRIPTION
Handle the case where get customer meta is called and the caller doesn't specify any meta keys to get.  Proper response is to return all well defined meta instead of an error.

Should never happen with the standard WPEC checkout user interface, but if someone customized the UI and there aren't any meta items on the screen it would generate an error response back to javascript that doesn't match the code documentation.
