### PR TITLE
#969 refer to 969

### DIFF
--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -418,7 +418,11 @@ jQuery(document).ready(function ($) {
 			return true;
 		} else {
 			var action_buttons = jQuery( 'input[name="wpsc_ajax_action"]', jQuery( this ) );
-			var action = action_buttons[0].value;
+			if(action_buttons.length > 0){
+				var action = action_buttons[0].value;	
+			} else {
+				var action = action_buttons.value;
+			}
 			form_values = jQuery(this).serialize() + '&action=' + action;
 
 			// Sometimes jQuery returns an object instead of null, using length tells us how many elements are in the object, which is more reliable than comparing the object to null


### PR DESCRIPTION
If action_buttons wasn't an object/array would fail.

In our wpec templates, and even the default one it should just be
pulling the action button directly, not multiple. Though I am sure there
are times there are more than one. (Maybe if you have a widget or
something?) Either way both ways will now work.
