### PR TITLE
wp-e-commerce.js changes should force browser and cache reload

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/page.php
+++ b/wpsc-components/theme-engine-v1/helpers/page.php
@@ -350,12 +350,13 @@ function wpsc_enqueue_user_script_and_css() {
 		// file when it changes, even though the WPEC version is not changing. This should also eliminate
 		// nearly all cases of having to ask a user "did you clear your browser cache?" when they report
 		// an unusual behavior.
-		$wp_ecommerce_js_version = $version_identifier . '-' . filemtime( WPSC_CORE_JS_PATH . '/wp-e-commerce.js' );
+		$wpec_js_version = $version_identifier . '-' . filemtime( WPSC_CORE_JS_PATH . '/wp-e-commerce.js' );
 
-		wp_enqueue_script( 'wp-e-commerce', WPSC_CORE_JS_URL . '/wp-e-commerce.js', array( 'jquery' ), $wp_ecommerce_js_version );
+		wp_enqueue_script( 'wp-e-commerce', WPSC_CORE_JS_URL . '/wp-e-commerce.js', array( 'jquery' ), $wpec_js_version );
 
 		if ( defined( WPEC_LOAD_DEPRECATED ) && WPEC_LOAD_DEPRECATED ) {
-			wp_enqueue_script( 'wpsc-deprecated', WPSC_CORE_JS_URL . '/wpsc-deprecated.js', false, $version_identifier );
+			$wpec_js_version = $version_identifier . '-' . filemtime( WPSC_CORE_JS_PATH . '/wpsc-deprecated.js' );
+			wp_enqueue_script( 'wpsc-deprecated', WPSC_CORE_JS_URL . '/wpsc-deprecated.js', 'wp-e-commerce', $wpec_js_version );
 		}
 
 		wp_enqueue_script( 'wp-e-commerce-dynamic', home_url( '/index.php?wpsc_user_dynamic_js=true' ), false, $version_identifier );


### PR DESCRIPTION
To help devs who are working on WPeC, and anyone who may deploy a site n WPeC and want to make a change to the WPeC javascript, add a file timestamp on to the version information for the javascript file.  This will force browsers and caches to use the new version of the file when it changes, even though the WPEC version is not changing. 

This should also eliminate nearly all cases of having to ask a user "did you clear our browser cache?" when they report an unusual behavior.

_UPDATE_
*The timestamp on the js version on the wp-e-commerce works so well let's do the same thing on the deprecated js

*The Deprecated js enqueue is no dependant on the wp-e-commerce js, this maintains the proper order
