### PR TITLE
Colorbox CSS - Remove IE6 hack.

### DIFF
--- a/wpsc-core/js/wpsc_colorbox.css
+++ b/wpsc-core/js/wpsc_colorbox.css
@@ -44,19 +44,3 @@
         #cboxLoadingGraphic{background:url(../images/loading.gif) no-repeat center center;}
         #cboxClose{position:absolute; bottom:0; right:0; background:url(../images/controls.png) no-repeat -25px 0; width:25px; height:25px; text-indent:-9999px;}
         #cboxClose:hover{background-position:-25px -25px;}
-
-/*
-  The following fixes a problem where IE7 and IE8 replace a PNG's alpha transparency with a black fill
-  when an alpha filter (opacity change) is set on the element or ancestor element.  This style is not applied to or needed in IE9.
-  See: http://jacklmoore.com/notes/ie-transparency-problems/
-*/
-.cboxIE #cboxTopLeft,
-.cboxIE #cboxTopCenter,
-.cboxIE #cboxTopRight,
-.cboxIE #cboxBottomLeft,
-.cboxIE #cboxBottomCenter,
-.cboxIE #cboxBottomRight,
-.cboxIE #cboxMiddleLeft,
-.cboxIE #cboxMiddleRight {
-    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#00FFFFFF,endColorstr=#00FFFFFF);
-}


### PR DESCRIPTION
Remove support for IE6 transparency hack. We don't include the required images anyway (so wasn't working). Plus: http://www.ie6countdown.com/
