### PR TITLE
Fix warning in PayPal Express when DB is not setup

### DIFF
--- a/wpsc-merchants/paypal-express.merchant.php
+++ b/wpsc-merchants/paypal-express.merchant.php
@@ -1032,5 +1032,5 @@ function paypal_deformatNVP( $nvpstr ) {
 	return $nvpArray;
 }
 
-if ( in_array( 'wpsc_merchant_paypal_express', get_option( 'custom_gateway_options' ) ) )
+if ( in_array( 'wpsc_merchant_paypal_express', get_option( 'custom_gateway_options', array() ) ) )
 	add_action('init', 'paypal_processingfunctions');


### PR DESCRIPTION
Provided a default value of an empty array to get_option() in the
PayPal Express merchant.

This PR fixes #1042
