### PR TITLE
Only show upgrade notices if DB is set up.

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/page.php
+++ b/wpsc-components/theme-engine-v1/helpers/page.php
@@ -239,19 +239,25 @@ function wpsc_database_update_notice() { ?>
 
 
 function wpsc_theme_admin_notices() {
-	// Database update notice is most important
-	if ( get_option ( 'wpsc_version' ) < 3.8 ) {
+	
+	// Check to see if WPEC is installed before showing upgrade notices.
+	if( false !== get_option( 'wpsc_version' ) ) {
 
-		add_action ( 'admin_notices', 'wpsc_database_update_notice' );
+		// Database update notice is most important
+		if ( get_option ( 'wpsc_version' ) < 3.8 ) {
 
-	// If that's not an issue check if theme updates required
-	} else {
+			add_action ( 'admin_notices', 'wpsc_database_update_notice' );
 
-		if ( get_option('wpsc_ignore_theme','') == '' ) {
-			add_option('wpsc_ignore_theme',false);
-		}
-		if (!get_option('wpsc_ignore_theme')) {
-			add_action( 'admin_notices', 'wpsc_theme_upgrade_notice' );
+		// If that's not an issue check if theme updates required
+		} else {
+
+			if ( get_option('wpsc_ignore_theme','') == '' ) {
+				add_option('wpsc_ignore_theme',false);
+			}
+			if (!get_option('wpsc_ignore_theme')) {
+				add_action( 'admin_notices', 'wpsc_theme_upgrade_notice' );
+			}
+
 		}
 
 	}


### PR DESCRIPTION
Fixes #1044 by checking to see if the wpsc_version option is set before
using it to decide which upgrade notices to display.

The diff looks like I did more than I did. There's just an extra if around the code that displays the upgrade notices, and the indents have been updated to reflect that.
