### PR TITLE
Allow deprecated functions during DB upgrades

### DIFF
--- a/wpsc-admin/db-upgrades/upgrade.php
+++ b/wpsc-admin/db-upgrades/upgrade.php
@@ -19,6 +19,9 @@ function _wpsc_maybe_upgrade() {
 	if ( ! _wpsc_needs_upgrade() )
 		return;
 
+	if ( ! defined( 'WPSC_LOAD_DEPRECATED' ) )
+		define( 'WPSC_LOAD_DEPRECATED', true );
+
 	for ( $i = $current_db_ver + 1; $i <= WPSC_DB_VERSION; $i ++ ) {
 		$file_path = WPSC_FILE_PATH . '/wpsc-admin/db-upgrades/routines/' . $i . '.php';
 


### PR DESCRIPTION
Fixes #1049.

I'm not sure if this is the best way to do this, but unless we want to go back through the DB upgrade routines and fix them I don't really see another way.

I also worry about someone trying to defining the WPSC_LOAD_DEPRECATED constant somewhere else, after this one has been defined, causing an error, but that may be their problem that they didn't check first.
