### PR TITLE
Fix typo in word 'deprecated'

### DIFF
--- a/wpsc-includes/wpsc-deprecated-meta.php
+++ b/wpsc-includes/wpsc-deprecated-meta.php
@@ -41,14 +41,14 @@
 // meta deprecations for 3.8.14
 
 // enable deprecation handling for customer meta with key 'checkout_details'
-define( '_wpsc_depcrecate_customer_checkout_details', true );
+define( '_wpsc_deprecate_customer_checkout_details', true );
 
 //
 //////////////////// End deprecation Handling Control //////////////////////////
 
 
 // manage deprecation of customer meta with key 'checkout_details'
-if ( _wpsc_depcrecate_customer_checkout_details ) {
+if ( _wpsc_deprecate_customer_checkout_details ) {
 
 	/**
 	 * Function to call to convert/delete/translate the customer meta value checkout_details


### PR DESCRIPTION
Fixes typos discussed in #1053.

I'm throwing this PR up so the fix is ready to go in case there's no reason to keep the typo in the constant name.
