### PR TITLE
Only define constant if it's not defined.

### DIFF
--- a/wpsc-includes/wpsc-deprecated-meta.php
+++ b/wpsc-includes/wpsc-deprecated-meta.php
@@ -41,7 +41,8 @@
 // meta deprecations for 3.8.14
 
 // enable deprecation handling for customer meta with key 'checkout_details'
-define( 'WPSC_DEPRECATE_CUSTOMER_CHECKOUT_DETAILS', true );
+if ( ! defined( 'WPSC_DEPRECATE_CUSTOMER_CHECKOUT_DETAILS') )
+	define( 'WPSC_DEPRECATE_CUSTOMER_CHECKOUT_DETAILS', true );
 
 //
 //////////////////// End deprecation Handling Control //////////////////////////


### PR DESCRIPTION
A bit of safety, as @JeffPyeBrook mentioned in #1053
