### PR TITLE
Disable checkout submit after submission.

### DIFF
--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -453,7 +453,6 @@ jQuery(document).ready(function ($) {
 	
 	jQuery( 'form.wpsc_checkout_forms' ).on( 'submit', function( evt ) {
 		jQuery( 'input[type="submit"]', this ).prop( { 'disabled': true } );
-		evt.preventDefault();
 	});
 	// Finished with disabling the checkout submit button.
 

--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -444,6 +444,18 @@ jQuery(document).ready(function ($) {
 
 	});
 
+
+	/**
+	 * Disable the submit button on the checkout form when the form is submitted
+	 * to prevent double-submission, (Double submission is confirmed to happen
+	 * in IE10. See https://github.com/wp-e-commerce/WP-e-Commerce/issues/1038 )
+	 */
+	
+	jQuery( 'form.wpsc_checkout_forms' ).on( 'submit', function( evt ) {
+		jQuery( this ).find( 'input[type="submit"]').attr( 'disabled', true );
+	});
+	// Finished with disabling the checkout submit button.
+
 	// Submit the product form using AJAX
 	jQuery( 'form.product_form, .wpsc-add-to-cart-button-form' ).on( 'submit', function() {
 		// we cannot submit a file through AJAX, so this needs to return true to submit the form normally if a file formfield is present

--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -452,7 +452,8 @@ jQuery(document).ready(function ($) {
 	 */
 	
 	jQuery( 'form.wpsc_checkout_forms' ).on( 'submit', function( evt ) {
-		jQuery( this ).find( 'input[type="submit"]').attr( 'disabled', true );
+		jQuery( 'input[type="submit"]', this ).prop( { 'disabled': true } );
+		evt.preventDefault();
 	});
 	// Finished with disabling the checkout submit button.
 


### PR DESCRIPTION
Add Javascript to disable and submit buttons, input[type=“submit”], in
the checkout form when the form is submitted. This way anyone with
Javascript enabled can’t double-submit a purchase.

This is at least a partial fix for #1038.