### PR TITLE
Update wpsc-shopping_cart_page.php

### DIFF
--- a/wpsc-theme/wpsc-shopping_cart_page.php
+++ b/wpsc-theme/wpsc-shopping_cart_page.php
@@ -462,14 +462,15 @@ endif;
          </tr>
       <?php endif; ?>
 
-      <?php if(wpsc_has_tnc()) : ?>
          <tr>
             <td colspan='2'>
-                <label for="agree"><input id="agree" type='checkbox' value='yes' name='agree' /> <?php printf(__("I agree to the <a class='thickbox' target='_blank' href='%s' class='termsandconds'>Terms and Conditions</a>", "wpsc"), esc_url( home_url( "?termsandconds=true&amp;width=360&amp;height=400" ) ) ); ?> <span class="asterix">*</span></label>
                </td>
          </tr>
-      <?php endif; ?>
       </table>
+            <?php if(wpsc_has_tnc()) : ?>
+
+                <label for="agree"><input id="agree" type='checkbox' value='yes' name='agree' /> <?php printf(__("I agree to the <a class='thickbox' target='_blank' href='%s' class='termsandconds'>Terms and Conditions</a>", "wpsc"), esc_url( home_url( "?termsandconds=true&amp;width=360&amp;height=400" ) ) ); ?> <span class="asterix">*</span></label>
+                      <?php endif; ?>
 
 <!-- div for make purchase button -->
       <div class='wpsc_make_purchase'>


### PR DESCRIPTION
Put Terms and Conditions outside the checkout table, otherwise you can check Billing same as Shipping without checking Ts & Cs.
