### PR TITLE
User Profile Display and Update

### DIFF
--- a/wpsc-components/theme-engine-v1/templates/functions/wpsc-user_log_functions.php
+++ b/wpsc-components/theme-engine-v1/templates/functions/wpsc-user_log_functions.php
@@ -35,24 +35,53 @@ function validate_form_data() {
 			$bad_input = false;
 			if ( $form_data['mandatory'] == 1 ) {
 				switch ( $form_data['type'] ) {
-					case "email":
-						if ( !preg_match( "/^[a-zA-Z0-9._-]+@[a-zA-Z0-9-.]+\.[a-zA-Z]{2,5}$/", $value ) ) {
+					case 'email':
+						if ( ! preg_match( "/^[a-zA-Z0-9._-]+@[a-zA-Z0-9-.]+\.[a-zA-Z]{2,5}$/", $value ) ) {
 							$any_bad_inputs = true;
 							$bad_input = true;
 						}
+
 						break;
 
-					case "delivery_country":
-						if ( ($value != null ) ) {
-							wpsc_update_customer_meta( 'shipping_country', $value );
+						$delivery_country = wpsc_get_customer_meta( 'shippingcountry' );
+						$billing_country  = wpsc_get_customer_meta( 'billingcountry'  );
+						$delivery_region  = wpsc_get_customer_meta( 'shippingregion'  );
+						$billing_region   = wpsc_get_customer_meta( 'billingregion'   );
+
+					case 'country':
+						// if it is an array then the firs element is the country, second is the region id
+						if ( is_array( $value ) ) {
+							wpsc_update_customer_meta(  'billingcountry' , $value[0] );
+							wpsc_update_customer_meta(  'billingregion' , $value[1] );
+						} else if ( is_string( $value ) ) {
+							wpsc_update_customer_meta(  'billingcountry' , $value );
+						} else {
+							$bad_input = true;
 						}
+
+						break;
+
+					case 'delivery_country':
+						// if it is an array then the firs element is the country, second is the region id
+						if ( is_array( $value ) ) {
+							wpsc_update_customer_meta(  'shippingcountry' , $value[0] );
+							wpsc_update_customer_meta(  'shippingregion' , $value[1] );
+						} else if ( is_string( $value ) ) {
+							wpsc_update_customer_meta(  'shippingcountry' , $value );
+						} else {
+							$bad_input = true;
+						}
+
 						break;
 
 					default:
-						if ( empty( $value ) )
+						if ( empty( $value ) ) {
 							$bad_input = true;
+						}
+
 						break;
 				}
+
 				if ( $bad_input === true ) {
 
 					switch ( $form_data['name'] ) {
@@ -230,6 +259,7 @@ function wpsc_display_form_fields() {
 						echo "<br /><select name='collected_data[" . $form_field['id'] . "][1]'>" . nzshpcrt_region_list( $country_code, $region ) . "</select>";
 					}
 					break;
+
 				case "email":
 					echo "<input type='text' value='" . $meta_data[$form_field['id']] . "' name='collected_data[" . $form_field['id'] . "]' />";
 					break;

--- a/wpsc-includes/wpsc-countries.class.php
+++ b/wpsc-includes/wpsc-countries.class.php
@@ -419,7 +419,7 @@ class WPSC_Countries {
 			$wpsc_country = self::$all_wpsc_country_from_country_id->value( $country_id );
 
 			if ( $wpsc_country->has_regions() ) {
-				$regions = $wpsc_country->regions();
+				$regions = $wpsc_country->regions( $as_array );
 			}
 		}
 

--- a/wpsc-includes/wpsc-country.class.php
+++ b/wpsc-includes/wpsc-country.class.php
@@ -396,10 +396,32 @@ class WPSC_Country {
 	 *
 	 * @param boolean return the result as an array, default is to return the result as an object
 	 *
-	 * @return array of WPSC_Region
+	 * @return array of WPSC_Region objects, indexed by region id, sorted by region
 	 */
-	public function regions() {
-		return $this->_regions->data();
+	public function regions( $as_array = false ) {
+		$regions_list = $this->_regions->data();
+
+		usort( $regions_list, array( __CLASS__, '_compare_regions_by_name' ) );
+
+		if ( $as_array ) {
+
+			foreach ( $regions_list as $region_key => $wpsc_region ) {
+				$region = get_object_vars( $wpsc_region );
+
+				$keys = array_keys( $region );
+				foreach ( $keys as $index => $key ) {
+					if ( substr( $key, 0, 1 ) == '_' ) {
+						$keys[$index] = substr( $key, 1 );
+					}
+				}
+
+				$region = array_combine( $keys, array_values( $region ) );
+
+				$regions_list[$region_key] = $region;
+			}
+		}
+
+		return $regions_list;
 	}
 
 	/**
@@ -621,6 +643,19 @@ class WPSC_Country {
 		WPSC_Countries::clear_cache();
 
 		return $country_id_from_db;
+	}
+
+
+	/**
+	 * Comapre regions using regions's name
+	 *
+	 * @param unknown $a instance of WPSC_Country class
+	 * @param unknown $b instance of WPSC_Country class
+	 *
+	 * @return 0 if country names are the same, -1 if country name of a comes before country b, 1 otherwise
+	 */
+	private static function _compare_regions_by_name( $a, $b ) {
+		return strcmp( $a->name(), $b->name() );
 	}
 
 	/**

--- a/wpsc-includes/wpsc-deprecated-meta.php
+++ b/wpsc-includes/wpsc-deprecated-meta.php
@@ -177,35 +177,35 @@ if ( WPSC_DEPRECATE_CUSTOMER_CHECKOUT_DETAILS ) {
 				switch ( $form_field['type'] ) {
 					case 'delivery_country':
 						if ( is_array( $meta_value ) && count( $meta_value ) == 2 ) {
-							wpsc_update_visitor_meta( 'shippingcountry', $meta_value[0], $id );
-							wpsc_update_visitor_meta( 'shippingregion', $meta_value[1], $id );
+							wpsc_update_visitor_meta( $id , 'shippingcountry', $meta_value[0] );
+							wpsc_update_visitor_meta( $id, 'shippingregion', $meta_value[1] );
 						} else {
 							if ( is_array( $meta_value ) ) {
 								$meta_value = $meta_value[0];
 							}
-							wpsc_update_visitor_meta( 'shippingcountry', $meta_value, $id );
-							wpsc_update_visitor_meta( 'shippingregion', $id );
+							wpsc_update_visitor_meta( $id, 'shippingcountry', $meta_value );
+							wpsc_update_visitor_meta( $id , 'shippingregion' );
 						}
 
 						break;
 
 					case 'country':
 						if ( is_array( $meta_value ) && count( $meta_value ) == 2 ) {
-							wpsc_update_visitor_meta( 'billingcountry', $meta_value[0], $id );
-							wpsc_update_visitor_meta( 'billingregion', $meta_value[1], $id );
+							wpsc_update_visitor_meta( $id, 'billingcountry', $meta_value[0] );
+							wpsc_update_visitor_meta( $id, 'billingregion', $meta_value[1] );
 						} else {
 							if ( is_array( $meta_value ) ) {
 								$meta_value = $meta_value[0];
 							}
 
-							wpsc_update_visitor_meta( 'billingcountry', $meta_value, $id );
-							wpsc_update_visitor_meta( 'billingregion', $id );
+							wpsc_update_visitor_meta( $id, 'billingcountry', $meta_value );
+							wpsc_update_visitor_meta( $id, 'billingregion' );
 						}
 
 						break;
 
 					default:
-						wpsc_update_visitor_meta( $meta_key, $meta_value, $id );
+						wpsc_update_visitor_meta( $id, $meta_key, $meta_value );
 						break;
 				}
 			}


### PR DESCRIPTION
- Fix empty region list on account page
- Use profile will save and recall values properly
- Region list is returned as array when "as_array" is true
- Region properties when returned as an array lose the '_' orefix used for class private variables.
- Region list is returned sorted by region name
- Fixed parameter order on wpsc_update_visitor_meta
