### PR TITLE
Visitor Meta Cleanup Hardening

### DIFF
--- a/wpsc-includes/wpsc-meta-visitor.php
+++ b/wpsc-includes/wpsc-meta-visitor.php
@@ -484,7 +484,7 @@ function wpsc_delete_visitor( $visitor_id ) {
 function wpsc_get_expired_visitor_ids() {
 
 	if ( ! _wpsc_visitor_database_ready() ) {
-		return false;
+		return array();
 	}
 
 	global $wpdb;
@@ -1230,3 +1230,34 @@ function _wpsc_updated_visitor_meta_billingcountry( $meta_value, $meta_key, $vis
 }
 
 add_action( 'wpsc_updated_visitor_meta_billingcountry', '_wpsc_updated_visitor_meta_billingcountry' , 1 , 3 );
+
+
+/**
+ * delete a visitor via ajax
+ *
+ * @since 3.8.14
+ *
+ * @access private
+ * @var  mixed $meta_value Optional. Metadata value.
+ * @return none
+ */
+function wpsc_delete_visitor_ajax() {
+
+	$visitor_id_to_delete = $_POST['wpsc_visitor_id'];
+	$security_nonce 	  = $_POST['wpsc_security'];
+
+	$delete_visitor_nonce_action = 'wpsc_delete_visitor_id_' .  $visitor_id_to_delete;
+
+	if ( ! wp_verify_nonce( $security_nonce, $delete_visitor_nonce_action ) ) {
+		// This nonce is not valid.
+		die( 'Security check' );
+	} else {
+		wpsc_delete_visitor( $visitor_id );
+	}
+
+	exit( 0 );
+}
+
+
+add_action( 'wp_ajax_wpsc_delete_visitor'       		, 'wpsc_delete_visitor_ajax' );
+add_action( 'wp_ajax_nopriv_wpsc_validate_customer'		, 'wpsc_delete_visitor_ajax' );


### PR DESCRIPTION
**Fixes**
Visitor meta cleanup determines the list of expired visitor IDs, then for each ID uses AJAX to request that the visitor is deleted.  This fixes several issues.
- Any hooks attached to deleting a visitor while is_admin() is true will now run when a visitor is deleted
- Memory usage is no longer excessive.  Because each visitor is deleted in it's own envelope of HTTP processing slow memory growth is no longer an issue when deleting hundreds or thousands of users
- If the time allotted for deleting users is reached, or the memory used while deleting users reaches a threshold, the delete user processed is stopped. Prior to the process being stopped a cron task is scheduled to delete the remaining users.  This cron will run a small after a short delay but will not wait for the next hourly delete visitor cron cleanup.  This addresses the issue where more visitor are created in an hour than can be deleted in a single pass of the visitor cleanup routine.
- If an some type of severe error occurs deleting a visitor it does not stop the processing for other users.  The single request to delete the visitor will fail, but other continue because they are being processed in a different HTTP context.

**Other enhancements**
To help diagnose visitor cleanup cron issues a non-autoload option is saved every time visitor cleanup runs.  The option contains the last run time as a string. Our TBD WPeC health check plugin or dashboard widget can grab this value.

Closes issue #982
