### PR TITLE
Visitor Authentication Security Hardening

### DIFF
--- a/wpsc-core/wpsc-constants.php
+++ b/wpsc-core/wpsc-constants.php
@@ -47,14 +47,25 @@ function wpsc_core_load_session() {
  * The core WPEC constants necessary to start loading
  */
 function wpsc_core_constants() {
-	if ( ! defined( 'WPSC_URL' ) )
+	if ( ! defined( 'WPSC_URL' ) ) {
 		define( 'WPSC_URL', plugins_url( '', __FILE__ ) );
+	}
 
 	// Define Plugin version
 	define( 'WPSC_VERSION'            , '3.8.14-dev' );
 	define( 'WPSC_MINOR_VERSION'      , 'e8a508c011' );
 	define( 'WPSC_PRESENTABLE_VERSION', '3.8.14-dev' );
 
+	// Define a salt to use when we hash, WPSC_SALT may be defined for us in our config file, so check first
+	if ( ! defined( 'WPSC_SALT' ) ) {
+		if ( defined( 'AUTH_SALT' ) ) {
+			define( 'WPSC_SALT', AUTH_SALT );
+		} else {
+			define( 'WPSC_SALT', hash_hmac( 'md5', __FUNCTION__, __FILE__ ) );
+		}
+	}
+
+	// Define the current databse version
 	define( 'WPSC_DB_VERSION'         , 10 );
 
 	// Define Debug Variables for developers, if they haven't already been defined

--- a/wpsc-includes/customer-private.php
+++ b/wpsc-includes/customer-private.php
@@ -169,7 +169,7 @@ function _wpsc_create_customer_id_cookie( $id, $fake_it = false ) {
 	$expire = time() + WPSC_CUSTOMER_DATA_EXPIRATION; // valid for 48 hours
 	$data   = $id . $expire;
 
-	$key = wp_hash( _wpsc_visitor_security_key( $id ) . '|' . $expire );
+	$key = hash_hmac( 'md5', _wpsc_visitor_security_key( $id ) . '|' . $expire, WPSC_SALT );
 
 	$hash   = hash_hmac( 'md5', $data, $key );
 	$cookie = $id . '|' . $expire . '|' . $hash;
@@ -203,13 +203,13 @@ function _wpsc_validate_customer_cookie() {
 
 	// check to see if the ID is valid, it must be an integer, empty test is because old versions of php
 	// can return true on empty string
-	if ( ! empty( $id ) &&  ctype_digit( $id ) ) {
+	if ( ! empty( $id ) &&  is_numeric( $id ) ) {
 		$id = intval( $id );
 		$security_key = _wpsc_visitor_security_key( $id );
 
 		// if a user is found keep checking, user not found clear the cookie and return invalid
 		if ( ! empty( $security_key ) ) {
-			$key = wp_hash( $security_key . '|' . $expire );
+			$key = hash_hmac( 'md5', $security_key, WPSC_SALT );
 			$hmac = hash_hmac( 'md5', $data, $key );
 
 			// integrity check


### PR DESCRIPTION
**Insipred by CVE-2014-0166 resolved in WordPress 3.8.2**
Instead of using wp_hash, a pluggable that can be overridden we use hash_hmac with a wll defined WPSC_SALT
Introduced WPSC_SALT an constant that can be defined in our config files, or takes on the value of the WordPress Authentication salt.
If the WordPress authentication salt is not available a unqiue salt is created using the file name, which should be cosntant, and the file path, which should vary from installation.to installation.

**Also...**
Removed a call to ctype, this library may not be available on all servers

Resolves #1037
