### PR TITLE
Fix terms and conditions hiding when shipping same as billing is checked

### DIFF
--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -183,8 +183,7 @@ function wpsc_update_customer_meta( response ) {
 						}
 					} else {
 						var current_value = jQuery( this ).val();
-						var new_value = meta_value;
-						if ( jQuery( this ).val() != meta_value ) {
+						if ( current_value != meta_value ) {
 							jQuery( this ).val( meta_value );
 						}
 					}
@@ -377,13 +376,22 @@ function wpsc_adjust_checkout_form_element_visibility() {
 	var shipping_row = jQuery( "#shippingSameBilling" ).closest( "tr" );
 	
 	if( jQuery("#shippingSameBilling").is(":checked") ) { 
-		jQuery( shipping_row ).siblings( ":not( .checkout-heading-row , :has( .custom_gateway ) ) ").hide();
+		jQuery( shipping_row ).siblings( ":not( .checkout-heading-row ,  :has( #agree ), :has( .custom_gateway ) ) ").hide();
 		jQuery( "#shippingsameasbillingmessage" ).show();
 	} else {
 		jQuery( shipping_row ).siblings().show();
 		jQuery( "#shippingsameasbillingmessage" ).hide();		
 	} 
 	
+	if( jQuery("#shippingSameBilling").is(":checked") ) { 
+		jQuery( shipping_row ).siblings( ":not( .checkout-heading-row , :has( #agree ), :has( .custom_gateway ) ) ").hide();
+		jQuery( "#shippingsameasbillingmessage" ).show();
+	} else {
+		jQuery( shipping_row ).siblings().show();
+		jQuery( "#shippingsameasbillingmessage" ).hide();		
+	} 
+	
+
 	// set the visibility of the shipping state input fields
 	var shipping_country = jQuery( "#shippingcountry" ).val();
 	var shipping_state_element = jQuery( "input[data-wpsc-meta-key='shippingstate']" ) ;

--- a/wpsc-theme/wpsc-shopping_cart_page.php
+++ b/wpsc-theme/wpsc-shopping_cart_page.php
@@ -465,7 +465,7 @@ endif;
       <?php if(wpsc_has_tnc()) : ?>
          <tr>
             <td colspan='2'>
-                <label for="agree"><input id="agree" type='checkbox' value='yes' name='agree' /> <?php printf(__("I agree to the <a class='thickbox' target='_blank' href='%s' class='termsandconds'>Terms and Conditions</a>", "wpsc"), esc_url( home_url( "?termsandconds=true&amp;width=360&amp;height=400" ) ) ); ?> <span class="asterix">*</span></label>
+               <input id="agree" type='checkbox' value='yes' name='agree' /> <label for="agree"><?php printf(__("I agree to the <a class='thickbox' target='_blank' href='%s' class='termsandconds'>Terms and Conditions</a>", "wpsc"), esc_url( home_url( "?termsandconds=true&amp;width=360&amp;height=400" ) ) ); ?> <span class="asterix">*</span></label>
                </td>
          </tr>
       <?php endif; ?>


### PR DESCRIPTION
_Also..._
- The INPUT element for the checkbox was being placed inside the label field for the checkbox,  moved it to adjacent
- Removed unreferenced variable from the javascript

Closes issue #1085
