### PR TITLE
Fix issue where checkout field validation messages were not being displayed

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -7,7 +7,7 @@ if ( isset( $_GET['termsandconds'] ) && 'true' == $_GET['termsandconds'] )
 	add_action( 'init', 'wpsc_show_terms_and_conditions' );
 
 if ( isset( $_REQUEST['wpsc_action'] ) && ($_REQUEST['wpsc_action'] == 'submit_checkout') ) {
-	add_action( 'init', 'wpsc_submit_checkout', 10 );
+	add_action( 'init', 'wpsc_submit_checkout', 10, 0 );
 }
 
 if ( isset( $_REQUEST['wpsc_action'] ) && ($_REQUEST['wpsc_action'] == 'cart_html_page') )


### PR DESCRIPTION
The collected data parameter on the submit checkout ajax function controls whether the checkout data is validated.

If the action is called without 0,the default is to have one parameter, and because it isn't set during ajax, WordPress sends an uninitialized ,value, and the default value in the function definition does not get set.

Closes issue #1083
