### PR TITLE
wrong function call

### DIFF
--- a/wpsc-includes/misc.functions.php
+++ b/wpsc-includes/misc.functions.php
@@ -171,7 +171,7 @@ function wpsc_get_country( $country_code ) {
 function wpsc_get_region( $region_id ) {
 	$country_id = WPSC_Countries::get_country_id_by_region_id( $region_id );
 	$wpsc_region = new WPSC_Region( $country_id, $region_id );
-	return $wpsc_region->name();
+	return $wpsc_region->get_name();
 }
 
 function nzshpcrt_display_preview_image() {


### PR DESCRIPTION
Got a fatal error on sales log page for an order:

Fatal error: Call to undefined method WPSC_Region::name() in D:\wamp\www\latestwpec\wp-content\plugins\WP-e-Commerce-master\wpsc-includes\misc.functions.php on line 174
