### PR TITLE
Use incorrect legacy capitialization for checkout class

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -705,7 +705,7 @@ function wpsc_submit_checkout( $collected_data = true ) {
 			$tax_percentage = 0.00;
 		}
 		$total = $wpsc_cart->calculate_total_price();
-		
+
 		$args = array(
 			'totalprice'       => $total,
 			'statusno'         => '0',
@@ -829,7 +829,7 @@ function wpsc_change_tax() {
 
 	global $wpsc_checkout;
 	if ( empty( $wpsc_checkout ) ) {
-		$wpsc_checkout = new WPSC_Checkout();
+		$wpsc_checkout = new wpsc_checkout();
 	}
 
 	$replacements = array();

--- a/wpsc-components/theme-engine-v1/templates/functions/wpsc-user_log_functions.php
+++ b/wpsc-components/theme-engine-v1/templates/functions/wpsc-user_log_functions.php
@@ -155,7 +155,7 @@ function wpsc_display_form_fields() {
 	global $wpdb, $user_ID, $wpsc_purchlog_statuses, $gateway_checkout_form_fields, $wpsc_checkout;
 
 	if ( empty( $wpsc_checkout ) )
-		$wpsc_checkout = new WPSC_Checkout();
+		$wpsc_checkout = new wpsc_checkout();
 
 	$meta_data = wpsc_get_customer_meta( 'checkout_details' );
 	$meta_data = apply_filters( 'wpsc_user_log_get', $meta_data, $user_ID );

--- a/wpsc-includes/customer-ajax.php
+++ b/wpsc-includes/customer-ajax.php
@@ -580,7 +580,7 @@ add_action( 'wpsc_updated_visitor_meta', '_wpsc_vistor_shipping_same_as_billing_
 function _wpsc_get_country_and_region_replacements( $replacements = null, $replacebilling = true, $replaceshipping = true ) {
 	global $wpsc_checkout;
 	if ( empty( $wpsc_checkout ) ) {
-		$wpsc_checkout = new WPSC_Checkout();
+		$wpsc_checkout = new wpsc_checkout();
 	}
 
 	if ( empty( $replacements ) ) {

--- a/wpsc-theme/functions/wpsc-user_log_functions.php
+++ b/wpsc-theme/functions/wpsc-user_log_functions.php
@@ -126,7 +126,7 @@ function wpsc_display_form_fields() {
 	global $wpdb, $user_ID, $wpsc_purchlog_statuses, $gateway_checkout_form_fields, $wpsc_checkout;
 
 	if ( empty( $wpsc_checkout ) )
-		$wpsc_checkout = new WPSC_Checkout();
+		$wpsc_checkout = new wpsc_checout();
 
 	$meta_data = wpsc_get_customer_meta( 'checkout_details' );
 	$meta_data = apply_filters( 'wpsc_user_log_get', $meta_data, $user_ID );


### PR DESCRIPTION
Avoids causing backwards compatibility issues

Closes issue #1116
