### PR TITLE
Localization of WPeC administration javascript variables is now more explicit

### DIFF
--- a/wpsc-admin/js/wp-e-commerce-admin.js
+++ b/wpsc-admin/js/wp-e-commerce-admin.js
@@ -22,13 +22,7 @@ if ( typeof wpsc_admin_vars !== undefined ) {
 	var base_url 						= wpsc_admin_vars['base_url'];
 	var WPSC_URL 						= wpsc_admin_vars['WPSC_URL'];
 	var WPSC_IMAGE_URL 					= wpsc_admin_vars['WPSC_IMAGE_URL'];
-	var WPSC_DIR_NAME 					= wpsc_admin_vars['WPSC_DIR_NAME'];
-	var WPSC_IMAGE_URL 					= wpsc_admin_vars['WPSC_IMAGE_URL'];
-	var fileLoadingImage 				= wpsc_admin_vars['fileLoadingImage'];
-	var fileBottomNavCloseImage 		= wpsc_admin_vars['fileBottomNavCloseImage'];
 	var fileThickboxLoadingImage 		= wpsc_admin_vars['fileThickboxLoadingImage'];
-	var resizeSpeed 					= wpsc_admin_vars['resizeSpeed'];
-	var borderSize 						= wpsc_admin_vars['borderSize'];
 	var hidden_boxes 					= wpsc_admin_vars['hidden_boxes'];
 	var IS_WP27 						= wpsc_admin_vars['IS_WP27'];
 	var TXT_WPSC_DELETE 				= wpsc_admin_vars['TXT_WPSC_DELETE'];

--- a/wpsc-core/wpsc-deprecated.php
+++ b/wpsc-core/wpsc-deprecated.php
@@ -1844,7 +1844,6 @@ function _wpsc_deprecated_javascript_localization_vars() {
 
 	$wpsc_deprecated_js_vars = array();
 
-	$wpsc_deprecated_js_vars['base_url'] 				= site_url(); //admin-legacy.js
 	$wpsc_deprecated_js_vars['WPSC_DIR_NAME'] 			= WPSC_DIR_NAME;
 	$wpsc_deprecated_js_vars['fileLoadingImage'] 		= WPSC_CORE_IMAGES_URL . '/loading.gif';
 	$wpsc_deprecated_js_vars['fileBottomNavCloseImage'] = WPSC_CORE_IMAGES_URL . '/closelabel.gif';


### PR DESCRIPTION
- The loop that was taking the localized admin js vars out of the localization structure and putting them into the window content has been replaced by explicit assignments.  Although it is a little more code than the prior loop it should now be easier to see what is happening.
- For localized js vars added after 3.8.14 three utility functions have been provided to access localized vars

```
 wpsc_admin_var_get ( name )
 wpsc_admin_var_set ( name, value )
 wpsc_admin_var_isset ( name, value );
```

**Also...**
Updated an incomplete comment related to the WPeC visitor cookie

This is the admin side of the audit required to close issue #1110
