### PR TITLE
Data Map class can fail in a confusing way if constructed incorrectly

### DIFF
--- a/wpsc-includes/wpsc-data-map.class.php
+++ b/wpsc-includes/wpsc-data-map.class.php
@@ -25,14 +25,18 @@ final class WPSC_Data_Map {
 	 *
 	 * @since 3.8.14
 	 *
-	 * @param string  		a map name to uniquely identify this map so it can be saved and restored
-	 * @param string|array  a callback function to re-generate the map if it can't be reloaded when it is neaded
+	 * @param string         $map_name       a map name to uniquely identify this map so it can be
+	 *                                       saved and restored
+	 *
+	 * @param string|array   $map_callback   a callback function to re-generate the map if it can't be
+	 *                                       reloaded when it is needed. The data map callback function will
+	 *                                       be called with a single parameter, the data map
 	 *
 	 */
 	public function __construct( $map_name = '', $map_callback = null ) {
 
-		$this->_map_name 		= $map_name;
-		$this->_map_callback 	= $map_callback;
+		$this->_map_name     = $map_name;
+		$this->_map_callback = $map_callback;
 
 		// if our map is names it means we want to save the map for use some time in the future
 		if ( ! empty( $this->_map_name ) ) {
@@ -216,14 +220,14 @@ final class WPSC_Data_Map {
 
 				if ( ! $already_invoking_callback ) {
 					$already_invoking_callback = true;
-
 					$this->_map_data = array();
 
-					call_user_func( $this->_map_callback );
+					// callback has a single parameter, the data map
+					call_user_func( $this->_map_callback, $this );
 
 					if ( ! is_array( $this->_map_data ) ) {
 						$this->_map_data = array();
-						$this->_dirty = true;
+						$this->_dirty    = true;
 					}
 				} else {
 					if ( is_array( $this->_map_callback ) )  {
@@ -248,7 +252,6 @@ final class WPSC_Data_Map {
 		}
 
 		return is_array( $this->_map_data );
-
 	}
 
 	/**
@@ -263,7 +266,6 @@ final class WPSC_Data_Map {
 	public function initialized() {
 		return is_array( $this->_map_data );
 	}
-
 
 	/**
 	 * is the data map dirty
@@ -300,8 +302,8 @@ final class WPSC_Data_Map {
 	 * @since 3.8.14
 	 *
 	 */
-	public $_map_name     = null;
-	public $_map_callback = null;
-	public $_map_data     = null;
+	public  $_map_name     = null;
+	public  $_map_callback = null;
+	public  $_map_data     = null;
 	private $_dirty       = false;
 }


### PR DESCRIPTION
Protect against class consumer using a recursive data map creation callback.  Pretty easy to detect the condition and report it.
