### PR TITLE
Add filter to allow re-calculate shipping quotes message to change

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -36,7 +36,7 @@ if ( ! get_option( 'wpsc_checkout_form_sets' ) ) {
 }
 
 // if we add and wpec admin javascript will add the localizations
-add_filter( '_wpsc_javascript_localizations', '_wpsc_admin_localizations', 1 );
+add_filter( 'wpsc_javascript_localizations', '_wpsc_admin_localizations', 1 );
 
 /**
  * wpsc_query_vars_product_list sets the ordering for the edit-products page list
@@ -686,7 +686,7 @@ function _wpsc_admin_localizations( $localizations ) {
 	$localizations['TXT_WPSC_IF_WEIGHT_IS'] = '"' . esc_js( __( 'If weight is ', 'wpsc' ) ) . '"';
 
 	// we only want to add these localizations once, it should happen on the first admin script load
-	remove_filter( '_wpsc_javascript_localizations', '_wpsc_admin_localizations', 1 );
+	remove_filter( 'wpsc_javascript_localizations', '_wpsc_admin_localizations', 1 );
 
 	return $localizations;
 }
@@ -699,7 +699,7 @@ function _wpsc_enqueue_wp_e_commerce_admin( ) {
 	if ( ! $already_enqueued ) {
 		$version_identifier = WPSC_VERSION . '.' . WPSC_MINOR_VERSION;
 		wp_enqueue_script( 'wp-e-commerce-admin-js',  WPSC_URL . '/wpsc-admin/js/wp-e-commerce-admin.js', false, false, $version_identifier );
-		wp_localize_script( 'wp-e-commerce-admin-js', 'wpsc_admin_vars', _wpsc_javascript_localizations() );
+		wp_localize_script( 'wp-e-commerce-admin-js', 'wpsc_admin_vars', wpsc_javascript_localizations() );
 		$already_enqueued = true;
 	}
 }
@@ -1128,7 +1128,7 @@ add_filter( 'favorite_actions', 'wpsc_fav_action' );
 function wpsc_print_admin_scripts() {
 	$version_identifier = WPSC_VERSION . '.' . WPSC_MINOR_VERSION;
 	wp_enqueue_script( 'wp-e-commerce-admin', WPSC_CORE_JS_URL . '/wp-e-commerce.js', array( 'jquery' ), $version_identifier );
-	wp_localize_script( 'wp-e-commerce-admin', 'wpsc_ajax', _wpsc_javascript_localizations() );
+	wp_localize_script( 'wp-e-commerce-admin', 'wpsc_ajax', wpsc_javascript_localizations() );
 }
 
 /**

--- a/wpsc-components/theme-engine-v1/helpers/page.php
+++ b/wpsc-components/theme-engine-v1/helpers/page.php
@@ -358,7 +358,7 @@ function wpsc_enqueue_user_script_and_css() {
 		}
 
 		wp_enqueue_script( 'wp-e-commerce', WPSC_CORE_JS_URL . '/wp-e-commerce.js', array( 'jquery' ), $version_identifier );
-		wp_localize_script( 'wp-e-commerce', 'wpsc_vars', _wpsc_javascript_localizations() );
+		wp_localize_script( 'wp-e-commerce', 'wpsc_vars', wpsc_javascript_localizations() );
 
 		wp_enqueue_script( 'livequery',                   WPSC_URL 			. '/wpsc-admin/js/jquery.livequery.js',   array( 'jquery' ), '1.0.3' );
 		if ( get_option( 'product_ratings' ) == 1 )

--- a/wpsc-core/wpsc-deprecated.php
+++ b/wpsc-core/wpsc-deprecated.php
@@ -1824,7 +1824,7 @@ function wpsc_empty_google_logs(){
  * @deprecated since 3.8.13.4
  */
 function wpsc_user_dynamic_js() {
-	_wpsc_deprecated_function( __FUNCTION__, '3.8.14', '_wpsc_javascript_localizations' );
+	_wpsc_deprecated_function( __FUNCTION__, '3.8.14', 'wpsc_javascript_localizations' );
 }
 
 /*

--- a/wpsc-core/wpsc-functions.php
+++ b/wpsc-core/wpsc-functions.php
@@ -167,7 +167,7 @@ function wpsc_checkout_unique_names() {
  *
  * @return array  local variables to add to both admin and front end WPEC javascript
  */
-function _wpsc_javascript_localizations( $localizations = false ) {
+function wpsc_javascript_localizations( $localizations = false ) {
 
 	if ( ! is_array( $localizations ) ) {
 		$localizations = array();
@@ -195,20 +195,20 @@ function _wpsc_javascript_localizations( $localizations = false ) {
 
 		$localizations['msg_shipping_need_recalc'] = __( 'Please click the <em>Calculate</em> button to refresh your shipping quotes, as your shipping information has been modified.', 'wpsc' );
 
-		/**
-		 * Change message theme presents to use when shipping quotes need to be recalcaulted.
-		 *
-		 * Useful in cases such as when a theme does not incldue the WPeC shipping calculator.
-		 *
-		 * @since 3.8.14
-		 *
-		 * @param string $msg Text of message to display when checkout page detects that the shipping quotes need to be recalculated.
-		 *
-		 */
 		$localizations['msg_shipping_need_recalc'] = apply_filters( 'wpsc_msg_shipping_need_recalc', $localizations['msg_shipping_need_recalc'] );
 	}
 
-	return apply_filters( '_wpsc_javascript_localizations', $localizations );
+	/**
+	 * a filter for WPeC components, plugins and themes to alter or add to what is localized into the WPeC javascript.
+	 *
+	 * @since 3.8.14
+	 *
+	 * @access public
+	 *
+	 * @param array $localizations array of localizations being sent to the javascript
+	 *
+	 */
+	return apply_filters( 'wpsc_javascript_localizations', $localizations );
 }
 
 /**

--- a/wpsc-includes/wpsc-checkout-localization.php
+++ b/wpsc-includes/wpsc-checkout-localization.php
@@ -1,7 +1,7 @@
 <?php
 
 // make the countries and regions information available to our javascript
-add_filter( '_wpsc_javascript_localizations', '_wpsc_countries_localizations', 10, 1 );
+add_filter( 'wpsc_javascript_localizations', '_wpsc_countries_localizations', 10, 1 );
 
 /**
  * add countries data to the wpec javascript localizations
@@ -68,7 +68,7 @@ function _wpsc_localize_checkout_item_name_to_from_id( $localizations ) {
 	return $localizations;
 }
 
-add_filter( '_wpsc_javascript_localizations', '_wpsc_localize_checkout_item_name_to_from_id', 10, 1 );
+add_filter( 'wpsc_javascript_localizations', '_wpsc_localize_checkout_item_name_to_from_id', 10, 1 );
 
 
 /**


### PR DESCRIPTION
Changed _wpsc_javascript_localizations to wpsc_javascript_localizations making it a generally available filter

_Also..._
added missing ',' to array declaration that is called for by coding standards
