### PR TITLE
Don't cut off checkout page when there are no quotes

### DIFF
--- a/wpsc-components/theme-engine-v1/templates/wpsc-shopping_cart_page.php
+++ b/wpsc-components/theme-engine-v1/templates/wpsc-shopping_cart_page.php
@@ -191,14 +191,6 @@ endif;
          <?php endif; ?>
 
          <?php wpsc_update_shipping_multiple_methods(); ?>
-
-
-         <?php if (!wpsc_have_shipping_quote()) : // No valid shipping quotes ?>
-               </table>
-               </div>
-			</div>
-            <?php return; ?>
-         <?php endif; ?>
       </table>
    <?php endif;  ?>
 


### PR DESCRIPTION
There was a path through the checkout page where the forms will not be displayed.

When there aren't any valid shipping quotes, perhaps because configured shipping modules do not have enough information, the cehckout form will now be displayed.

I think it's easy enough to to fix, but we will need a release note so that support and users who encounter this issue will know to update their theme file.
