### PR TITLE
Add constant to control deprecated js loading

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/page.php
+++ b/wpsc-components/theme-engine-v1/helpers/page.php
@@ -352,7 +352,7 @@ function wpsc_enqueue_user_script_and_css() {
 		wp_enqueue_script( 'jQuery' );
 		wp_enqueue_script( 'wp-e-commerce', WPSC_CORE_JS_URL . '/wp-e-commerce.js', array( 'jquery' ), $version_identifier );
 
-		if ( defined( 'WPEC_LOAD_DEPRECATED' ) && WPEC_LOAD_DEPRECATED ) {
+		if ( defined( 'WPEC_LOAD_DEPRECATED_JS' ) && WPEC_LOAD_DEPRECATED_JS ) {
 			wp_enqueue_script( 'wpsc-deprecated', WPSC_CORE_JS_URL . '/wpsc-deprecated.js', 'wp-e-commerce', $version_identifier );
 			wp_localize_script( 'wpsc-deprecated', 'wpsc_deprecated_js_vars', _wpsc_deprecated_javascript_localization_vars() );
 		}

--- a/wpsc-core/wpsc-constants.php
+++ b/wpsc-core/wpsc-constants.php
@@ -52,9 +52,17 @@ function wpsc_core_constants() {
 	}
 
 	// Define Plugin version
-	define( 'WPSC_VERSION'            , '3.8.14-dev' );
-	define( 'WPSC_MINOR_VERSION'      , 'e8a508c011' );
-	define( 'WPSC_PRESENTABLE_VERSION', '3.8.14-dev' );
+	if ( ! defined( 'WPSC_VERSION' ) ) {
+		define( 'WPSC_VERSION'            , '3.8.14-dev' );
+	}
+
+	if ( ! defined( 'WPSC_MINOR_VERSION' ) ) {
+		define( 'WPSC_MINOR_VERSION'      , 'e8a508c011' );
+	}
+
+	if ( ! defined( 'WPSC_PRESENTABLE_VERSION' ) ) {
+		define( 'WPSC_PRESENTABLE_VERSION', '3.8.14-dev' );
+	}
 
 	// Define a salt to use when we hash, WPSC_SALT may be defined for us in our config file, so check first
 	if ( ! defined( 'WPSC_SALT' ) ) {
@@ -90,6 +98,13 @@ function wpsc_core_constants() {
 	if ( ! defined( 'WPEC_LOAD_DEPRECATED' ) ) {
 		define( 'WPEC_LOAD_DEPRECATED', true );
 	}
+
+	// Do not require loading of deprecated js
+	// of this in future versions.
+	if ( ! defined( 'WPEC_LOAD_DEPRECATED_JS' ) ) {
+		define( 'WPEC_LOAD_DEPRECATED_JS', false );
+	}
+
 
 	define( 'WPSC_CUSTOMER_COOKIE', 'wpsc_customer_cookie_' . COOKIEHASH );
 	if ( ! defined( 'WPSC_CUSTOMER_COOKIE_PATH' ) )


### PR DESCRIPTION
- constant is off by default

_Also..._
- Wrapped WPeC version constants in if blocks.  This will let developers put something into their wp-config.php file that bumps version numbers automatically to force script reloads, or perhaps for other reasons  My preferred insert is appending the time stamp of the wp-e-commerce.js file to the version stamp.

Closes issue #1125
