### PR TITLE
User account page updates

### DIFF
--- a/wpsc-components/theme-engine-v1/templates/wpsc-account-edit-profile.php
+++ b/wpsc-components/theme-engine-v1/templates/wpsc-account-edit-profile.php
@@ -10,19 +10,9 @@
 ?>
 
 <form method="post">
-
-	<?php echo validate_form_data(); ?>
-
 	<table>
 
 		<?php wpsc_display_form_fields(); ?>
 
-		<tr>
-			<td></td>
-			<td>
-				<input type="hidden" value="true" name="submitwpcheckout_profile" />
-				<input type="submit" value="<?php _e( 'Save Profile', 'wpsc' ); ?>" name="submit" />
-			</td>
-		</tr>
 	</table>
 </form>

--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -253,7 +253,7 @@ function wpsc_check_for_shipping_recalc_needed( response ) {
 	// TODO: if shipping needs to be re-calculated we need to refresh the page.  This is the only option
 	// in version 3.8.14 and earlier.  Future versions should support replacing the shipping quote elements
 	// via AJAX
-	if ( response.hasOwnProperty( 'needs_shipping_recalc' ) ) {
+	if ( response.hasOwnProperty( 'needs_shipping_recalc' ) && jQuery( '#checkout_page_container' ).length ) {
 		if ( response.needs_shipping_recalc ) {
 
 			var form = jQuery('table.productcart' ).first();

--- a/wpsc-core/wpsc-deprecated.php
+++ b/wpsc-core/wpsc-deprecated.php
@@ -2037,3 +2037,48 @@ if ( isset( $_REQUEST['wpsc_admin_action'] ) && ($_REQUEST['wpsc_admin_action'] 
 function wpsc_css_header() {
 	_wpsc_deprecated_function( __FUNCTION__, '3.8.14' );
 }
+
+/**
+ * deprecating item filters from wpsc_display_form_fields() in release 3.8.13.4
+ *
+ *  @deprecated 3.8.14
+ *
+ * This function displays each of the form fields.
+ *
+ * Each of them are filterable via 'wpsc_account_form_field_$tag'
+ * where tag is permalink-styled name or uniquename. i.e. First Name under Shipping would be
+ * 'wpsc_account_form_field_shippingfirstname' - while Your Billing Details would be filtered
+ * via 'wpsc_account_form_field_your-billing-details'.
+ *
+ * @param varies  $meta_value
+ * @param string  $meta_key
+ * @param int     $visitor_id
+ *
+ */
+function wpsc_user_log_deprecated_filter_values( $meta_value, $meta_key, $visitor_id ) {
+	$filter = 'wpsc_account_form_field_' . $meta_key;
+	if ( has_filter( $filter ) ) {
+		$meta_value = apply_filters( $filter , esc_html( $meta_value ) );
+		_wpsc_doing_it_wrong( $filter, __( 'The filter being used has been deprecated. Use wpsc_get_visitor_meta or wpsc_get_visitor_meta_$neta_name instead.' ), '3.8.14' );
+	}
+
+	return $meta_value;
+}
+add_filter( 'wpsc_get_visitor_meta', 'wpsc_user_log_deprecated_filter_values', 10, 3 );
+
+/**
+ * deprecating user log filter for getting all customer meta as an array.
+ *
+ *fs@deprecated 3.8.14
+ *
+ * @return none
+ */
+function wpsc_deprecated_filter_user_log_get() {
+	if ( has_filter( 'wpsc_user_log_get' ) ) {
+		$meta_data = wpsc_get_customer_meta( 'checkout_details' );
+		$meta_data = apply_filters( 'wpsc_user_log_get', $meta_data, wpsc_get_current_customer_id() );
+		wpsc_update_customer_meta( 'checkout_details', $meta_data );
+		_wpsc_doing_it_wrong( 'wpsc_user_log_get', __( 'The filter being used has been deprecated. Use wpsc_get_visitor_meta or wpsc_get_visitor_meta_$neta_name instead.' ), '3.8.14' );
+	}
+}
+add_filter( 'wpsc_start_display_user_log_form_fields', 'wpsc_deprecated_filter_user_log_get', 10, 0 );

--- a/wpsc-core/wpsc-functions.php
+++ b/wpsc-core/wpsc-functions.php
@@ -702,3 +702,20 @@ function wpsc_core_load_page_titles() {
 		$wpsc_page_titles = wpsc_get_page_post_names();
 }
 
+/**
+ * get the global checkout object, will create it
+ *
+ * @return wpsc_checkout       the global checkout object
+ */
+function wpsc_core_get_checkout() {
+	global $wpsc_checkout;
+
+	if ( empty( $wpsc_checkout ) || ! is_a( $wpsc_checkout, 'wpsc_checkout' ) ) {
+		$wpsc_checkout = new wpsc_checkout();
+	}
+
+	$wpsc_checkout->rewind_checkout_items();
+
+	return $wpsc_checkout;
+
+}

--- a/wpsc-includes/checkout.class.php
+++ b/wpsc-includes/checkout.class.php
@@ -315,12 +315,12 @@ class wpsc_checkout {
 				break;
 
 			case "country":
-				$output = wpsc_country_list( $this->checkout_item->id, false, $billing_country, $billing_region, $this->form_element_id() );
+				$output = wpsc_country_list( $this->checkout_item->id, null, $billing_country, $billing_region, $this->form_element_id() );
 				break;
 
 			case "delivery_country":
 				$checkoutfields = true;
-				$output = wpsc_country_list( $this->checkout_item->id, false, $delivery_country, $delivery_region, $this->form_element_id(), $checkoutfields );
+				$output = wpsc_country_list( $this->checkout_item->id, null, $delivery_country, $delivery_region, $this->form_element_id(), $checkoutfields );
 				break;
 
 			case "select":

--- a/wpsc-includes/shopping_cart_functions.php
+++ b/wpsc-includes/shopping_cart_functions.php
@@ -183,8 +183,6 @@ function wpsc_country_list( $form_id = null, $ajax = null, $selected_country = n
 
 	$output = '';
 
-	$selected_country = new WPSC_Country( $selected_country );
-
 	if ( $form_id != null ) {
 		$html_form_id = "region_country_form_$form_id";
 	} else {
@@ -192,13 +190,13 @@ function wpsc_country_list( $form_id = null, $ajax = null, $selected_country = n
 	}
 
 	if ( $shippingfields ) {
-		$js = '';
+		$js    = '';
 		$title = 'shippingcountry';
-		$id = 'shippingcountry';
+		$id    = 'shippingcountry';
 	} else {
-		$js = '';
+		$js    = '';
 		$title = 'billingcountry';
-		$id = 'billingcountry';
+		$id    = 'billingcountry';
 	}
 
 	if ( empty( $supplied_form_id ) ) {
@@ -213,7 +211,7 @@ function wpsc_country_list( $form_id = null, $ajax = null, $selected_country = n
 													'id'                    => $supplied_form_id,
 													'name'                  => "collected_data[{$form_id}][0]",
 													'class'                 => 'current_country wpsc-visitor-meta',
-													'selected'              => $selected_country->get_isocode(),
+													'selected'              => $selected_country,
 													'additional_attributes' => $additional_attributes,
 													'placeholder'           => __( 'Please select a country', 'wpsc' ),
 												)
@@ -392,11 +390,9 @@ function wpsc_checkout_shipping_state_and_region( $wpsc_checkout = null ) {
 	// check a new checkout form with all fields
 	$checkout_form = new WPSC_Checkout_Form( null, false );
 
-
 	// is the shipping country visible on the form, let's find out
 	$shipping_country_form_element = $checkout_form->get_field_by_unique_name( 'shippingcountry' );
 	$showing_shipping_country = (bool)$shipping_country_form_element->active;
-
 
 	// make sure the shipping state is the current checkout element
 	$wpsc_checkout->checkout_item = $wpsc_checkout->get_checkout_item( 'shippingstate' );

--- a/wpsc-includes/wpsc-meta-util.php
+++ b/wpsc-includes/wpsc-meta-util.php
@@ -761,7 +761,7 @@ function _wpsc_vistor_shipping_same_as_billing_meta_update( $meta_value, $meta_k
 
 		if ( $shipping_same_as_billing ) {
 
-			$meta_key_starts_with_billing = strpos( $meta_key, 'billing', 0 ) === 0;
+			$meta_key_starts_with_billing  = strpos( $meta_key, 'billing', 0 ) === 0;
 			$meta_key_starts_with_shipping = strpos( $meta_key, 'shipping', 0 ) === 0;
 
 			if ( $meta_key_starts_with_billing ) {


### PR DESCRIPTION
- Code copied from core of checkout page, account form generation now uses same logic as checkout page
- Deprecated functions updated to include user log specific filters, as visitor filters perform the same function WPeC wide

Addresses issue #1174, merge PR #1173 before this PR is merged

_also..._
Checks for checkout page container present prior to scrolling window
