### PR TITLE
Fix issue that was false alarming a recursion condition in country class initialization

### DIFF
--- a/wpsc-admin/db-upgrades/routines/11.php
+++ b/wpsc-admin/db-upgrades/routines/11.php
@@ -32,15 +32,15 @@ function _wpsc_fixup_united_kingdom() {
 		)
 	);
 
-	if ( WPSC_Countries::get_country( 'UK' ) ) {
-			$wpsc_country = new WPSC_Country(
-			array(
-					'isocode'     => 'UK',
-					'visible'     => '0',
-			)
-		);
+	if ( $wpsc_country = WPSC_Countries::get_country( 'UK' ) ) {
+		$wpsc_country = new WPSC_Country(
+											array(
+												'visible'     => '0',
+												'isocode'     => 'UK',
+											)
+										);
 
-			$wpsc_country->set( '_is_country_legacy', true );
+		$wpsc_country->set( '_is_country_legacy', true );
 	}
 
 }

--- a/wpsc-includes/wpsc-countries.class.php
+++ b/wpsc-includes/wpsc-countries.class.php
@@ -1412,10 +1412,6 @@ class WPSC_Countries {
 					$wpsc_country->_regions->map( $region->id, $wpsc_region );
 					$wpsc_country->_region_id_by_region_code->map( $region->code, $region->id );
 					$wpsc_country->_region_id_by_region_name->map( strtolower( $region->name ), $region->id );
-
-					self::$country_id_by_region_id->map( $region->id, $region->country_id );
-					self::$region_by_region_id->map( $region->id, $wpsc_region );
-					self::$region_code_by_region_id->map( $region->id, $region->code );
 				}
 			}
 
@@ -1478,10 +1474,6 @@ class WPSC_Countries {
 					$wpsc_country->_regions->map( $region->id, $wpsc_region );
 					$wpsc_country->_region_id_by_region_code->map( $region->code, $region->id );
 					$wpsc_country->_region_id_by_region_name->map( strtolower( $region->name ), $region->id );
-
-					self::$country_id_by_region_id->map( $region->id, $region->country_id );
-					self::$region_by_region_id->map( $region->id, $wpsc_region );
-					self::$region_code_by_region_id->map( $region->id, $region->code );
 				}
 			}
 
@@ -1490,6 +1482,80 @@ class WPSC_Countries {
 
 		self::$_dirty = true;
 	}
+
+
+	/**
+	 * saves country data to the database
+	 *
+	 * @access WPeC private
+	 *
+	 * @since 3.8.14
+	 *
+	 * @param array  key/value pairs that are put into the database columns
+	 *
+	 * @return int|boolean country_id on success, false on failure
+	 */
+	public static function _save_country_data( $country_data ) {
+		global $wpdb;
+
+		/*
+		 * We need to figure out if we are updating an existing country. There are three
+		 * possible unique identifiers for a country.  Look for a row that has any of the
+		 * identifiers.
+		 */
+		$country_id       = isset( $country_data['id'] )      ? intval( $country_data['id'] ) : 0;
+		$country_iso_code = isset( $country_data['isocode'] ) ? $country_data['isocode']      : '';
+
+		/*
+		 *  If at least one of the key feilds ins't present we aren'y going to continue, we can't reliably update
+		 *  a row in the table, nor could we insrt a row that could reliably be updated.
+		 */
+		if ( empty( $country_id ) && empty( $country_iso_code ) ) {
+			_wpsc_doing_it_wrong( __FUNCTION__, __( 'To insert a country either country id or country ISO code must be specified.', 'wpsc' ), '3.8.11' );
+			return false;
+		}
+
+		// check the database to find the country id
+		$sql = $wpdb->prepare(
+				'SELECT id FROM ' . WPSC_TABLE_CURRENCY_LIST . ' WHERE (`id` = %d ) OR ( `isocode` = %s ) ',
+				$country_id,
+				$country_iso_code
+		);
+
+		$country_id_from_db = $wpdb->get_var( $sql );
+
+		// do a little data clean up prior to inserting into the database
+		if ( isset( $country_data['has_regions'] ) ) {
+			$country_data['has_regions'] = $country_data['has_regions'] ? 1:0;
+		}
+
+		if ( isset( $country_data['visible'] ) ) {
+			$country_data['visible'] = $country_data['visible'] ? 1 : 0;
+		}
+
+		// insert or update the information
+		if ( empty( $country_id_from_db ) ) {
+			// we are doing an insert of a new country
+			$result = $wpdb->insert( WPSC_TABLE_CURRENCY_LIST, $country_data );
+			if ( $result ) {
+				$country_id_from_db = $wpdb->insert_id;
+			}
+		} else {
+			// we are doing an update of an existing country
+			if ( isset( $country_data['id'] ) ) {
+				// no nead to update the id to itself
+				unset( $country_data['id'] );
+			}
+			$wpdb->update( WPSC_TABLE_CURRENCY_LIST, $country_data, array( 'id' => $country_id_from_db, ), '%s', array( '%d', )  );
+		}
+
+		// clear the cached data, force a rebuild by getting a country
+		self::clear_cache();
+
+		return $country_id_from_db;
+	}
+
+
 }
 
 add_action( 'init', '_wpsc_make_countries_data_available' );

--- a/wpsc-includes/wpsc-country.class.php
+++ b/wpsc-includes/wpsc-country.class.php
@@ -28,7 +28,7 @@ class WPSC_Country {
 
 			if ( is_array( $country ) ) {
 				// if we get an array as an argument we are making a new country
-				$country_id_or_isocode = $this->_save_country_data( $country );
+				$country_id_or_isocode = WPSC_Countries::_save_country_data( $country );
 			}  else {
 				// we are constructing a country using a numeric id or ISO code
 				$country_id_or_isocode = $country;
@@ -577,78 +577,6 @@ class WPSC_Country {
 	}
 
 	/**
-	 * saves country data to the database
-	 *
-	 * @access public
-	 *
-	 * @since 3.8.14
-	 *
-	 * @param array  key/value pairs that are put into the database columns
-	 *
-	 * @return int|boolean country_id on success, false on failure
-	 */
-	public function _save_country_data( $country_data ) {
-		global $wpdb;
-
-		/*
-		 * We need to figure out if we are updating an existing country. There are three
-		 * possible unique identifiers for a country.  Look for a row that has any of the
-		 * identifiers.
-		 */
-		$country_id       = isset( $country_data['id'] )      ? intval( $country_data['id'] ) : 0;
-		$country_iso_code = isset( $country_data['isocode'] ) ? $country_data['isocode']      : '';
-
-		/*
-		 *  If at least one of the key feilds ins't present we aren'y going to continue, we can't reliably update
-		 *  a row in the table, nor could we insrt a row that could reliably be updated.
-		 */
-		if ( empty( $country_id ) && empty( $country_iso_code ) ) {
-			_wpsc_doing_it_wrong( __FUNCTION__, __( 'To insert a country either country id or country ISO code must be specified.', 'wpsc' ), '3.8.11' );
-			return false;
-		}
-
-		// check the database to find the country id
-		$sql = $wpdb->prepare(
-				'SELECT id FROM ' . WPSC_TABLE_CURRENCY_LIST . ' WHERE (`id` = %d ) OR ( `isocode` = %s ) ',
-				$country_id,
-				$country_iso_code
-			);
-
-		$country_id_from_db = $wpdb->get_var( $sql );
-
-		// do a little data clean up prior to inserting into the database
-		if ( isset( $country_data['has_regions'] ) ) {
-			$country_data['has_regions'] = $country_data['has_regions'] ? 1:0;
-		}
-
-		if ( isset( $country_data['visible'] ) ) {
-			$country_data['visible'] = $country_data['visible'] ? 1 : 0;
-		}
-
-		// insert or update the information
-		if ( empty( $country_id_from_db ) ) {
-			// we are doing an insert of a new country
-			$result = $wpdb->insert( WPSC_TABLE_CURRENCY_LIST, $country_data );
-			if ( $result ) {
-				$country_id_from_db = $wpdb->insert_id;
-			}
-		} else {
-			// we are doing an update of an existing country
-			if ( isset( $country_data['id'] ) ) {
-				// no nead to update the id to itself
-				unset( $country_data['id'] );
-			}
-			$wpdb->update( WPSC_TABLE_CURRENCY_LIST, $country_data, array( 'id' => $country_id_from_db, ), '%s', array( '%d', )  );
-		}
-
-		// clear the cahned data, force a rebuild
-		WPSC_Countries::clear_cache();
-
-		return $country_id_from_db;
-	}
-
-
-	/**
 	 * Comapre regions using regions's name
 	 *
 	 * @param unknown $a instance of WPSC_Country class
@@ -672,22 +600,22 @@ class WPSC_Country {
 	 *
 	 * @return void
 	 */
-	public $_id = null;
-	public $_name      = null;
-	public $_isocode = null;
-	public $_currency_name = '';
-	public $_currency_code = '';
-	public $_currency_symbol = '';
-	public $_currency_symbol_html = '';
-	public $_code = '';
-	public $_has_regions = false;
-	public $_tax = '';
-	public $_continent = '';
-	public $_visible = true;
-	public $_region_id_by_region_code  = null;
-	public $_region_id_by_region_name	 = null;
+	public $_id                           = null;
+	public $_name                         = null;
+	public $_isocode                      = null;
+	public $_currency_name                = '';
+	public $_currency_code                = '';
+	public $_currency_symbol              = '';
+	public $_currency_symbol_html         = '';
+	public $_code                         = '';
+	public $_has_regions                  = false;
+	public $_tax                          = '';
+	public $_continent                    = '';
+	public $_visible                      = true;
+	public $_region_id_by_region_code     = null;
+	public $_region_id_by_region_name     = null;
 	public $_region_id_to_region_code_map = null;
-	public $_regions 	                  = null;
+	public $_regions                      = null;
 
 	/////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// As a result of merging the legacy WPSC_Country class we no longer need several of the public class

--- a/wpsc-includes/wpsc-data-map.class.php
+++ b/wpsc-includes/wpsc-data-map.class.php
@@ -221,10 +221,10 @@ final class WPSC_Data_Map {
 
 				// the callback could be a string or an array, we can keep track of
 				// who's call we are processing tp avoid a recursion problem, just in case!
-				$callback_unqiue_key = md5( json_encode( $this->_map_callback ) );
+				$callback_unique_key = md5( json_encode( $this->_map_callback ) );
 
-				if ( ! in_array( $callback_unqiue_key, $already_invoking_callback ) ) {
-					$already_invoking_callback[] = $callback_unqiue_key;
+				if ( ! in_array( $callback_unique_key, $already_invoking_callback ) ) {
+					$already_invoking_callback[$callback_unique_key] = true;
 
 					$this->_map_data = array();
 
@@ -244,7 +244,7 @@ final class WPSC_Data_Map {
 					_wpsc_doing_it_wrong( $function , __( 'WPSC_Data_Map map creation callback is recursively calling itself.', 'wpsc' ), '3.8.14' );
 				}
 
-				unset( $already_invoking_callback[$callback_unqiue_key] );
+				unset( $already_invoking_callback[$callback_unique_key] );
 
 			}
 


### PR DESCRIPTION
- Replaced missing code for tracking initializations in progress.  Not having the code was causing initialization recursion warning false alarms
- Removed superfluous code that was checking for, and forcing the premature,  initialization of country data maps.

_Also..._
- Make sure country being updated exists in upgrade routine
- Fix some typos in variable names
- Code from WPSC_Country class that was directly accessing database now part of the WPSC_Countries class.  All direct access to countries data is now in the WPSC_Countries service class.  All the code that accesses the database for countries is together.
