### PR TITLE
Make check for localized variable more specific and use a string for the returned type

### DIFF
--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -487,7 +487,7 @@ function wpsc_adjust_checkout_form_element_visibility() {
 function wpsc_countries_lists_handle_restrictions() {
 
 	// if there isn't a list of acceptable countries then we don't have any work to do
-	if ( typeof wpsc_acceptable_shipping_countries !== undefined ) {
+	if ( typeof wpsc_acceptable_shipping_countries === "object" ) {
 
 		// we need to know the current billing country
 		var current_billing_country  = wpsc_get_value_from_wpsc_meta_element( 'billingcountry' );


### PR DESCRIPTION
Eliminated javascript warning error caused by trying to do acceptabile countries processing when not appropriate
