### PR TITLE
Added logic to reformat regions array 

### DIFF
--- a/wpsc-taxes/controllers/taxes_controller.class.php
+++ b/wpsc-taxes/controllers/taxes_controller.class.php
@@ -518,7 +518,7 @@ class wpec_taxes_controller {
 				foreach ( $select_settings as $key => $setting ) {
 					if ( $key == 'label' ) {
 						continue;
-					} elseif ( $key == 'value') {
+					} elseif ( $key == 'value' ) {
 						$setting = esc_attr( $setting );
 					}
 					$returnable .= $key."='".$setting."'";

--- a/wpsc-taxes/models/taxes.class.php
+++ b/wpsc-taxes/models/taxes.class.php
@@ -351,6 +351,14 @@ class wpec_taxes {
 
 		$regions = $wpsc_country->get_regions_array();
 
+		// backwards compatability at version 3.8.14, the rest of the module needs region to be called 'region_code'.
+		// TODO: update taxes module to use WPSC_Region objects
+		foreach ( $regions as $index => $region ) {
+			$region['region_code'] = $region['code'];
+			unset( $region['region'] );
+			$regions[$index] = $region;
+		}
+
 		if ( isset( $country ) && 'all-markets' == $country ) {
 			return;
 		}


### PR DESCRIPTION
Changes into the special format used within the taxes module.  Taxes module should be updated to use the WPSC_Region object rather than an associative array.
