### PR TITLE
Backwards compatibility fixup for currencies

### DIFF
--- a/wpsc-includes/wpsc-countries.class.php
+++ b/wpsc-includes/wpsc-countries.class.php
@@ -389,6 +389,7 @@ class WPSC_Countries {
 				$currency_data->code        = $wpsc_country->get_currency_code();
 				$currency_data->symbol      = $wpsc_country->get_currency_symbol();
 				$currency_data->symbol_html = $wpsc_country->get_currency_symbol_html();
+				$currency_data->currency    = $wpsc_country->get_currency_name();
 			}
 		}
 
@@ -643,11 +644,18 @@ class WPSC_Countries {
 			return 0;
 		}
 
-		$currencies = self::$currencies;
+		$currencies = self::$currencies->data();
 
 		if ( $as_array ) {
-			$json = json_encode( $currencies );
-			$currencies = json_decode( $json, true );
+			$currencies_list = array();
+
+			foreach ( $currencies as $currencies_key => $currency ) {
+				$currency_array             = get_object_vars( $currency );
+				$currency_array['currency'] = $currency_array['name'];   // some  legacy code looks for 'currency' rather than name, so we put both in the array
+				$currencies_list[]          = $currency_array;
+			}
+
+			$currencies = $currencies_list;
 		}
 
 		// we have the return value in our country name to id map, all we have to do is swap the keys with the values

--- a/wpsc-merchants/paypal-standard.merchant.php
+++ b/wpsc-merchants/paypal-standard.merchant.php
@@ -793,14 +793,12 @@ function form_paypal_multiple() {
 		$paypal_currency_list = array_map( 'esc_sql', $wpsc_gateways['wpsc_merchant_paypal_standard']['supported_currencies']['currency_list'] );
 		$currency_list = WPSC_Countries::get_currencies( true );
 
-		foreach ( $currency_codes_in_commmon as $currency_code ) {
+		foreach ( $currency_list as $currency_item ) {
 			$selected_currency = '';
-			$currency_item = $currency_list[$currency_code];
-
 			if ( $current_currency == $currency_item['code'] ) {
 				$selected_currency = "selected='selected'";
 			}
-			$output .= "<option " . $selected_currency . " value='{$currency_item['code']}'>{$currency_item['currency']}</option>";
+			$output .= "<option " . $selected_currency . " value='{$currency_item['code']}'>{$currency_item['name']}</option>";
 		}
 		$output .= "
 				</select>


### PR DESCRIPTION
- added currency name to the currency list object
- add 'currency' as an alias for 'name' when returning currency array
- fix some miscoding in the currency list handling for the paypal gateway
