### PR TITLE
Add 'County' as region label for UK

### DIFF
--- a/wpsc-admin/db-upgrades/routines/13.php
+++ b/wpsc-admin/db-upgrades/routines/13.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Control database upgrade to version 11
+*
+* @access private
+* @since 3.8.14
+*
+*/
+function _wpsc_db_upgrade_13() {
+	_wpsc_add_region_labe_to_uk();
+}
+
+/**
+ * add the county region label to the uk
+ *
+ * @access private
+ * @since 3.8.14.1
+ */
+function _wpsc_add_region_labe_to_uk() {
+	$wpsc_country = new WPSC_Country( 'GB' );
+	$wpsc_country->set( 'region_label', __( 'County', 'wpsc' ) );
+}

--- a/wpsc-core/wpsc-constants.php
+++ b/wpsc-core/wpsc-constants.php
@@ -74,7 +74,7 @@ function wpsc_core_constants() {
 	}
 
 	// Define the current database version
-	define( 'WPSC_DB_VERSION', 12 );
+	define( 'WPSC_DB_VERSION', 13 );
 
 	// Define Debug Variables for developers, if they haven't already been defined
 	if ( ! defined( 'WPSC_DEBUG' ) ) {


### PR DESCRIPTION
- add 'County' as the region label for UK
- Incremented database version, added update routine for next version (13)

Addresses one of the issues in #1237
