### PR TITLE
Allow save of new custom checkout items

### DIFF
--- a/wpsc-admin/includes/settings-tabs/checkout.php
+++ b/wpsc-admin/includes/settings-tabs/checkout.php
@@ -171,6 +171,7 @@ class WPSC_Settings_Tab_Checkout extends WPSC_Settings_Tab {
 				'%s', // type
 				'%s', // active
 				'%s', // mandatory
+				'%s', // checkout set
 				'%s', // unique name
 			);
 


### PR DESCRIPTION
create unique name for custom items so that they can be stored into the database
resolves issue #1239
