### PR TITLE
Handle boolean meta value in a more backwards compatible way

### DIFF
--- a/wpsc-includes/wpsc-meta-util.php
+++ b/wpsc-includes/wpsc-meta-util.php
@@ -721,7 +721,33 @@ function _wpsc_has_visitor_location_changed( $visitor_id = false ) {
 	}
 }
 
+/**
+ * Tries to turn an arbitrary value into a avalid bool looking at the contents, including for strings like false and no, ...
+ * @param varies $value      value to boolify
+ * @return Ambigous <boolean, string>
+ */
+function _wpsc_make_value_into_bool( $value ) {
+	if ( ! is_bool( $value ) ) {
+		if ( empty( $value ) ) {
+			$value = false;
+		} elseif ( is_numeric( $value ) ) {
+			$value = (bool) $value;
+		} elseif ( is_string( $value ) ) {
+			$value = strtolower( $value );
+			if ( $value == 'no' || $value == 'false' ) {
+				$value = false;
+			} else {
+				$value = true;
+			}
+		} elseif ( is_array( $value ) ) {
+			$value = ! empty( $value );
+		} else {
+			$value = (bool) $value;
+		}
+	}
 
+	return $value;
+}
 
 /**
  * when visitor meta is updated we need to check if the shipping same as billing
@@ -741,7 +767,9 @@ function _wpsc_vistor_shipping_same_as_billing_meta_update( $meta_value, $meta_k
 
 	// if the shipping same as billing option is being checked then copy meta from billing to shipping
 	if ( $meta_key == 'shippingSameBilling' ) {
-		if ( $meta_value == 1 ) {
+		$meta_value = _wpsc_make_value_into_bool( $meta_value );
+
+		if ( $meta_value ) {
 
 			$checkout_names = wpsc_checkout_unique_names();
 


### PR DESCRIPTION
The shipping same as billing meta value can be stored in several different ways depending on the version of WPeC that saved it.  Added a utility function to convert an arbitrary value into a bool with just a little more intelligence than a cast or checking a non-empty string.

Resolves issue #1246
