### PR TITLE
Retain UK visibility on upgrade

### DIFF
--- a/wpsc-admin/db-upgrades/routines/11.php
+++ b/wpsc-admin/db-upgrades/routines/11.php
@@ -18,6 +18,21 @@ function _wpsc_db_upgrade_11() {
  * @since 3.8.14
  */
 function _wpsc_fix_united_kingdom() {
+
+	if ( $wpsc_country = WPSC_Countries::get_country( 'UK' ) ) {
+
+		$legacy_ok_country_was_visible = $wpsc_country->is_visible();
+
+		$wpsc_country = new WPSC_Country(
+				array(
+						'visible'     => '0',
+						'isocode'     => 'UK',
+				)
+		);
+
+		$wpsc_country->set( '_is_country_legacy', true );
+	}
+
 	$wpsc_country = new WPSC_Country(
 		array(
 				'country'     => __( 'United Kingdom', 'wpsc' ),
@@ -27,22 +42,11 @@ function _wpsc_fix_united_kingdom() {
 				'symbol_html' => __( '&#163;', 'wpsc' ),
 				'code'        => __( 'GBP', 'wpsc' ),
 				'continent'   => 'europe',
-				'visible'     => '1',
+				'visible'     =>  $legacy_ok_country_was_visible ? '0' : '1',
 				'has_regions' => '0',
 				'tax'         => '0',
 		)
 	);
-
-	if ( $wpsc_country = WPSC_Countries::get_country( 'UK' ) ) {
-		$wpsc_country = new WPSC_Country(
-			array(
-				'visible'     => '0',
-				'isocode'     => 'UK',
-			)
-		);
-
-		$wpsc_country->set( '_is_country_legacy', true );
-	}
 
 	//make sure base country is ok after the UK/GB fix
 	$base_country = get_option( 'base_country', '' );


### PR DESCRIPTION
use visibility from legacy UK country in new UK country.

Note taht for people that have already upgraded this doesn't change that the UK is now showing in the target market list where it didn't before, not way to know the state of the visibility
