### PR TITLE
Look at regions data rather than database field to determine status

### DIFF
--- a/wpsc-includes/wpsc-country.class.php
+++ b/wpsc-includes/wpsc-country.class.php
@@ -222,7 +222,7 @@ class WPSC_Country {
 	 * @return boolean	true if we have a region lsit for the nation, false otherwise
 	 */
 	public function has_regions() {
-		return $this->_has_regions;
+		return ( $this->_regions->count() > 0 );
 	}
 
 	/**


### PR DESCRIPTION
The has regions column in the database is no longer referenced in the class when checking to see if regions are available for a country
