### PR TITLE
Regions update correctly on shipping same as billing change

### DIFF
--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -233,18 +233,18 @@ function wpsc_update_customer_meta( response ) {
 							jQuery( this ).removeAttr( 'checked' );
 						}
 					} else if ( jQuery(this).hasClass('wpsc-region-dropdown') ) {
-						// we are going to skip updating teh region value because the select is dependant on 
-						// the value of other meta, specificially the billing or shipping country.
-						// rather than enforce a field order in the reponse we will take care of it by doing
+						// we are going to skip updating the region value because the select is dependant on 
+						// the value of other meta, specifically the billing or shipping country.
+						// rather than enforce a field order in the response we will take care of it by doing
 						// a second pass through the updates looking for only the region drop downs
-						''
+						;
 					} else if ( jQuery(this).hasClass('wpsc-country-dropdown') ) {
 						var current_value = jQuery( this ).val();
 						if ( current_value != meta_value ) {
 							jQuery( this ).val( meta_value );
 
 							// if we are updating a country drop down we need to make sure that 
-							// the correct regions ar in the list before we change the value
+							// the correct regions are in the list before we change the value
 							wpsc_update_regions_list_to_match_country( jQuery( this ) );
 						}
 					} else {
@@ -257,9 +257,8 @@ function wpsc_update_customer_meta( response ) {
 			});
 		});
 		
-		// this second pass through the properties only looks for region drop downs, thier
-		// contents is dependant on other meta values so we do these after evertything else has 
-		// been done
+		// this second pass through the properties only looks for region drop downs, their
+		// contents is dependant on other meta values so we do these after everything else has 
 		jQuery.each( customer_meta,  function( meta_key, meta_value ) {
 
 			// if there are other fields on the current page that are used to change the same meta value then
@@ -279,8 +278,6 @@ function wpsc_update_customer_meta( response ) {
 				}
 			});
 		});
-		
-		
 	}
 }
 


### PR DESCRIPTION
When shipping same as billing changes the country drop downs need to be updated first, then the region drop downs need to be filled with the current correct regions, then the current region needs to be set.

This change enforces this dependency order so that display is correct

Resolves issue #1280
