### PR TITLE
Show region label as placeholder in shipping calculator

### DIFF
--- a/wpsc-includes/shopping_cart_functions.php
+++ b/wpsc-includes/shopping_cart_functions.php
@@ -423,10 +423,14 @@ function wpsc_checkout_shipping_state_and_region( $wpsc_checkout = null ) {
 
 	$region_list = $wpsc_country->get_regions();
 
+	$placeholder = $wpsc_country->get( 'region_label' );
+	if ( empty ( $placeholder ) ) {
+		$placeholder = $wpsc_checkout->checkout_item->name;
+	}
 
 	$placeholder = apply_filters(
 									'wpsc_checkout_field_placeholder',
-									apply_filters( 'wpsc_checkout_field_name', $wpsc_checkout->checkout_item->name ),
+									apply_filters( 'wpsc_checkout_field_name',  $placeholder ),
 									$wpsc_checkout->checkout_item
 								);
 


### PR DESCRIPTION
If the region label is defined use it as the default placeholder
