### PR TITLE
Force clear of country cache after batch update

### DIFF
--- a/wpsc-admin/settings-page.php
+++ b/wpsc-admin/settings-page.php
@@ -636,6 +636,7 @@ final class WPSC_Settings_Page {
 				}
 			}
 
+			WPSC_Countries::clear_cache();
 			wpsc_core_flush_temporary_data();
 		}
 		$previous_currency = get_option( 'currency_type' );


### PR DESCRIPTION
In addition to clear of all other temporary data we force clear the countries data that was directly updated
