### PR TITLE
Introduce action hooks at the top and bottom of the coupon add/edit

### DIFF
--- a/wpsc-admin/display-coupon-add.php
+++ b/wpsc-admin/display-coupon-add.php
@@ -5,6 +5,8 @@
 			<table class="form-table">
 				<tbody>
 
+					<?php do_action( 'wpsc_coupon_add_top' ); ?>
+
 					<tr class="form-field">
 						<th scope="row" valign="top">
 							<label for="add_coupon_code"><?php _e( 'Coupon Code', 'wpsc' ); ?></label>
@@ -117,6 +119,8 @@
 							</div>
 						</td>
 					</tr>
+
+					<?php do_action( 'wpsc_coupon_add_bottom' ); ?>
 
 				</tbody>
 			</table>

--- a/wpsc-admin/display-coupon-edit.php
+++ b/wpsc-admin/display-coupon-edit.php
@@ -22,6 +22,8 @@ $coupon    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `" . WPSC_TABLE_COUP
 			<table class="form-table">
 				<tbody>
 
+					<?php do_action( 'wpsc_coupon_edit_top', $coupon_id, $coupon ); ?>
+
 					<tr class="form-field">
 						<th scope="row" valign="top">
 							<label for="edit_coupon_code"><?php _e( 'Coupon Code', 'wpsc' ); ?></label>
@@ -162,6 +164,8 @@ $coupon    = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM `" . WPSC_TABLE_COUP
 							<?php endforeach; ?>
 						</td>
 					</tr>
+
+					<?php do_action( 'wpsc_coupon_edit_top', $coupon_id, $coupon ); ?>
 
 				</tbody>
 			</table>


### PR DESCRIPTION
At the moment there is no way for other plugins to hook in and add their own form inputs to the coupon add/edit screen.

I'd like to be able to do this for the AffiliateWP integration for WP-e-Commerce for our affiliate coupon tracking feature.
