### PR TITLE
WPSC_Purchase_Log->is_transaction_completed() should check against array of filtered completed order statuses

### DIFF
--- a/wpsc-includes/purchase-log.class.php
+++ b/wpsc-includes/purchase-log.class.php
@@ -812,7 +812,7 @@ class WPSC_Purchase_Log {
 	}
 
 	public function is_transaction_completed() {
-		return $this->is_accepted_payment() || $this->is_job_dispatched() || $this->is_closed_order();
+		return WPSC_Purchase_Log::is_order_status_completed( $this->get( 'processed' ) );
 	}
 
 	public function is_order_received() {


### PR DESCRIPTION
Fix for #1360

Not sure if this is the best approach.

Both methods seem to do a similar job, but one is static and once is not.

Either way, if one method is deprecated the other will need to alias the remaining method.

I have taken a punt that the more recent method is the one which should be used to check order status - the naming of the method is more descriptive anyway.

I guess is_transaction_completed() could stay as there may be checks in future that require testing if the order status is complete and another condition.

Ben