### PR TITLE
Ensure default parameters are set for cart items.

### DIFF
--- a/wpsc-includes/cart-item.class.php
+++ b/wpsc-includes/cart-item.class.php
@@ -168,6 +168,11 @@ class wpsc_cart_item {
 		// The cart is in the cart item, which is in the cart, which is in the cart item, which is in the cart, which is in the cart item...
 		$this->cart = &$cart;
 
+		$parameters = wp_parse_args( $parameters, array(
+			'is_customisable' => false,
+			'file_data'       => null
+		) );
+
 		foreach ( $parameters as $name => $value ) {
 			$this->$name = $value;
 		}

--- a/wpsc-includes/cart.class.php
+++ b/wpsc-includes/cart.class.php
@@ -551,6 +551,11 @@ class wpsc_cart {
 		$edit_item       = false;
 		$variation_check = true;
 
+		$parameters = wp_parse_args( $parameters, array(
+			'quantity'         => 0,
+			'variation_values' => null
+		) );
+
 		if ( wpsc_product_has_variations( $product_id ) && is_null( $parameters['variation_values'] ) ) {
 			$variation_check = false;
 		}


### PR DESCRIPTION
A few PHP warning from trying to use array parameters that don.t exist.

Using wp_parse_args fixes it.

Please double check I have the right default values.
