### PR TITLE
Correct functioning of __empty() magic method.

### DIFF
--- a/wpsc-includes/product.class.php
+++ b/wpsc-includes/product.class.php
@@ -329,7 +329,7 @@ class WPSC_Product {
 	 */
 	public function __empty( $name ) {
 		$this->_maybe_lazy_load_property( $name );
-		return empty( $this->name );
+		return empty( $this->$name );
 	}
 
 	/**


### PR DESCRIPTION
Corrects the lack of a $ in __empty() thereby making is actually work
