### PR TITLE
Don't save cart to database when nothing has changed

### DIFF
--- a/wpsc-includes/wpsc-meta-visitor.php
+++ b/wpsc-includes/wpsc-meta-visitor.php
@@ -698,11 +698,7 @@ function _wpsc_calculate_cart_signature( $wpsc_cart ) {
 	unset( $cart_array['current_shipping_quote'] );
 	unset( $cart_array['cart_item'] );
 
-//	foreach ( $cart_array['cart_items'] as $index => $cart_item ) {
-//		$cart_array['cart_items'][$index]->cart = null;
-//	}
-
-	$raw_data = serialize( $cart_array );
+	$raw_data = json_encode( $cart_array );
 	$signature = md5( $raw_data );
 
 	return $signature;


### PR DESCRIPTION
Calculate a cart signature when a cart is loaded from the database
Recalculate the signature when a cart is being saved, compare the signatures, don't save if they are not different.
