### PR TITLE
Fix product category image displaying in other custom columns in the admin.

### DIFF
--- a/wpsc-admin/includes/save-data.functions.php
+++ b/wpsc-admin/includes/save-data.functions.php
@@ -89,8 +89,6 @@ function wpsc_custom_category_columns( $columns ) {
  * @return  string                Updated column output.
  */
 function wpsc_custom_category_column_data( $string, $column_name, $term_id ) {
-	global $wpdb;
-
 	if ( 'image' == $column_name ) {
 		$term = get_term_by( 'id', $term_id, 'wpsc_product_category' );
 		$image = wpsc_get_categorymeta( $term_id, 'image' );


### PR DESCRIPTION
Product category image should only be displayed in the image column in the admin, rather than all custom columns.

Currently if you add first custom columns the image displays in them too!
