### PR TITLE
Updated phpDoc block, avoid inspection warning

### DIFF
--- a/wpsc-includes/processing.functions.php
+++ b/wpsc-includes/processing.functions.php
@@ -6,7 +6,7 @@
  * @access public
  * @param mixed $price_in
  * @param mixed $args
- * @return void
+ * @return string
  */
 function wpsc_currency_display( $price_in, $args = null ) {
 	global $wpdb;


### PR DESCRIPTION
Return value was noted as void instead of string.  Caused inspection warnings.
