### PR TITLE
Make sure that updates are recorded when calculate is submitted

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -483,6 +483,18 @@ function wpsc_update_product_price() {
  */
 function wpsc_update_location() {
 	global $wpsc_cart;
+	
+	/*
+	 * WPeC's totally awesome checkout page shipping calculator has a submit button that will send
+	 * some of the shipping data to us in an AJAX request.  The format of the data as of version
+	 * 3.8.14.1 uses the 'collected_data' array format just like in checkout. We should process
+	 * this array in case it has some updates to the user meta (checkout information) that haven't been
+	 * recorded at the time the calculate button was clicked.
+	 */
+	if ( isset( $_POST['collected_data'] ) && is_array( $_POST['collected_data'] ) ) {
+		_wpsc_checkout_customer_meta_update( $_POST['collected_data'] );
+	}
+
 
 	$wpsc_cart->update_location();
 	$wpsc_cart->get_shipping_method();


### PR DESCRIPTION
WPeC's totally awesome checkout page shipping calculator has a submit button that will send some of the shipping data to us in an AJAX request.  The format of the data as of version 3.8.14.1 uses the 'collected_data' array format just like in checkout. We should process this array in case it has some updates to the user meta (checkout information) that haven't been recorded at the time the calculate button was clicked.
