### PR TITLE
WPeC's totally awesome checkout page shipping calculator has a submit bu...

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -489,11 +489,30 @@ function wpsc_update_location() {
 	global $wpsc_cart;
 
 	/*
+	 * Checkout page shipping calculator MAY provide a zip code using the identifier from prior
+	 * releases.  Let's check for that.
+	 */
+	if ( isset( $_POST['zipcode'] ) ) {
+		wpsc_update_customer_meta( 'shippingpostcode', $_POST['zipcode'] );
+	}
+
+	/*
+	 * Checkout page shipping calculator MAY provide a country code using the identifier from prior
+	 * releases.  Let's check for that.
+	 */
+	if ( isset( $_POST['country'] ) ) {
+		$wpsc_country = new WPSC_Country( $_POST['country'] );
+		wpsc_update_customer_meta( 'shippingcountry', $wpsc_country->get_isocode() );
+	}
+
+	/*
 	 * WPeC's totally awesome checkout page shipping calculator has a submit button that will send
 	 * some of the shipping data to us in an AJAX request.  The format of the data as of version
 	 * 3.8.14.1 uses the 'collected_data' array format just like in checkout. We should process
 	 * this array in case it has some updates to the user meta (checkout information) that haven't been
-	 * recorded at the time the calculate button was clicked.
+	 * recorded at the time the calculate button was clicked.  If the country or zip code is set using the
+	 * legacy 'country' or 'zip' code $_POST values they will be overwritten if they are also included
+	 * in the collected_data $_POST value.
 	 */
 	if ( isset( $_POST['collected_data'] ) && is_array( $_POST['collected_data'] ) ) {
 		_wpsc_checkout_customer_meta_update( $_POST['collected_data'] );
@@ -1139,13 +1158,17 @@ function _wpsc_checkout_customer_meta_update( $checkout_post_data ) {
 
 			switch ( $form_field['type'] ) {
 				case 'delivery_country':
-					if ( is_array( $meta_value ) && count( $meta_value ) == 2 ) {
-						wpsc_update_visitor_meta( $id , 'shippingcountry', $meta_value[0] );
-						wpsc_update_visitor_meta( $id, 'shippingregion', $meta_value[1] );
-					} else {
-						if ( is_array( $meta_value ) ) {
-							$meta_value = $meta_value[0];
+					if ( is_array( $meta_value ) ) {
+
+						if ( isset( $meta_value[0] ) ) {
+							wpsc_update_visitor_meta( $id, 'shippingcountry', $meta_value[0] );
 						}
+
+						if ( isset( $meta_value[1] ) ) {
+							wpsc_update_visitor_meta( $id, 'shippingregion', $meta_value[1] );
+						}
+
+					} else {
 						wpsc_update_visitor_meta( $id, 'shippingcountry', $meta_value );
 						wpsc_update_visitor_meta( $id, 'shippingregion', '' );
 					}


### PR DESCRIPTION
...tton that will send some of the shipping data to us in an AJAX request. The format of the data as of version 3.8.14.1 uses the 'collected_data' array format just like in checkout. We should process this array in case it has some updates to the user meta (checkout information) that haven't been recorded at the time the calculate button was clicked.
