### PR TITLE
No hidden pass by reference

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -35,18 +35,6 @@ function wpsc_is_single_product() {
 function wpsc_category_class() {
 	global $wpdb, $wp_query;
 
-/*
-	if( ! array_key_exists('taxonomy', $wp_query->query_vars) ) {
-		echo '">';
-	var_dump( $wp_query->query_vars );
-	exit;
-	}
-*/
-/*
-	echo '">';
-	var_dump( $wp_query->query_vars );
-	exit;
-*/
 	$category_nice_name = '';
 	if ( 'wpsc_product_category' == $wp_query->query_vars['taxonomy']  ) {
 		$catid = wpsc_get_the_category_id($wp_query->query_vars['term'],'slug');


### PR DESCRIPTION
I've been getting a lot of "PHP Strict standards:  Only variables should be passed by reference in /Users/John/Sites/wpec-dev/wp-content/plugins/wp-e-commerce/wpsc-components/theme-engine-v1/helpers/template-tags.php on line 647" in my debug.log, and discovered that the pass-by-reference is happening because array_shift() is being passed the result of an explode(). This removes that, and yoda-izes a the if condition.

Fixes #1429
