### PR TITLE
Honour the $no_decimals parameter of wpsc_the_product_price()

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -616,10 +616,20 @@ function wpsc_the_product_price( $no_decimals = false, $only_normal_price = fals
 	if ( wpsc_product_has_variations( $product_id ) ) {
 		$from_text = __( ' from %s', 'wpsc' );
 		$from_text = apply_filters( 'wpsc_product_variation_text', $from_text );
+
+		if( $no_decimals ) {
+			add_filter( 'wpsc_modify_decimals', '__return_zero' );
+		}
+
 		$output = wpsc_product_variation_price_from( $product_id, array(
 			'from_text'         => $from_text,
 			'only_normal_price' => $only_normal_price,
 		) );
+
+		if( $no_decimals ) {
+			remove_filter( 'wpsc_modify_decimals', '__return_zero' );
+		}
+		
 	} else {
 		$price = $full_price = get_post_meta( $product_id, '_wpsc_price', true );
 


### PR DESCRIPTION
Added the __return_zero() function to the wpsc_modify_decimals filter
if $no_decimals is true.

Fixes #1432.

Let me know if anyone thinks there will be problems with this approach. The `wpsc_modify_decimals` filter is applied in `wpsc_currency_display()`, which in turn is called by `wpsc_product_variation_price_from()`
