### PR TITLE
Don't remove decimals twice.

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -631,11 +631,6 @@ function wpsc_the_product_price( $no_decimals = false, $only_normal_price = fals
 				$price = $special_price;
 		}
 
-		if ( $no_decimals ) {
-			$price = explode( ".", $price );
-			$price = array_shift( $price );
-		}
-
 		$price = apply_filters( 'wpsc_do_convert_price', $price, $product_id );
 		$args = array(
 			'display_as_html' => false,


### PR DESCRIPTION
wpsc_currency_display() has its display_decimal_point argument set to
false when $no_decimals is set to true, so we don't need to explode()
the decimals off of the price in wpsc_the_product_price()

This is an even better fix for #1429 - it removes the problematic code entirely!