### PR TITLE
Region dropdown missing sub-array element (Bug Fix)

### DIFF
--- a/wpsc-includes/shopping_cart_functions.php
+++ b/wpsc-includes/shopping_cart_functions.php
@@ -344,7 +344,7 @@ function wpsc_checkout_billing_state_and_region( $wpsc_checkout = null ) {
 					. 'id="' . $region_form_id . '" '
 						. ' class="current_region wpsc-visitor-meta wpsc-region-dropdown" data-wpsc-meta-key="' . $title
 							. '"  title="' . $title . '" '
-								. 'name="collected_data['. $wpsc_checkout->checkout_item->id . ']" '
+								. 'name="collected_data['. $wpsc_checkout->checkout_item->id . '][1]" '
 									. $style
 										. ">\n\r ";
 


### PR DESCRIPTION
Working with a fellow developer - we determined that in checkout data that the Billing Region Dropdown didn't pass both the region ID as well as the Country ISO (as a two-element array for billingcountry)
The bug is that valid region/country pairs failed validation. I think this addresses some errors reported as issues but haven't specifically confirmed. (But the handling of billing region/country now matches shipping region/country)
