### PR TITLE
Feature: Add user-settable item count for Sales Logs per page

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -89,7 +89,7 @@ function wpsc_admin_edit_posts_orderby( $orderby_sql ) {
 add_filter( 'posts_orderby', 'wpsc_admin_edit_posts_orderby' );
 
 /**
- * setting the screen option to between 1 and 999
+ * setting the product & variations per page screen option to between 1 and 999
  *
  * @since 3.8
  * @access public
@@ -102,7 +102,7 @@ add_filter( 'posts_orderby', 'wpsc_admin_edit_posts_orderby' );
  * @return $value after changes...
  */
 function wpsc_set_screen_option($status, $option, $value){
-	if( in_array($option, array ("edit_wpsc_variation_per_page","edit_wpsc_product_per_page" )) ){
+	if( in_array($option, array ("edit_wpsc_variation_per_page","edit_wpsc_product_per_page", "wpsc_purchases_per_page" )) ){
 		if ( "edit_wpsc_variation_per_page" == $option ){
 			global $user_ID;
 			update_user_option($user_ID,'edit_wpsc-variation_per_page',$value);
@@ -264,6 +264,8 @@ function wpsc_admin_pages() {
 	add_action( 'load-post-new.php'          , 'wpsc_add_help_tabs' );
 	add_action( 'load-edit-tags.php'         , 'wpsc_add_help_tabs' );
 
+	// screen options on Sales Log
+	add_action( 'load-' . $purchase_logs_page , 'wpsc_add_purchase_logs_screen_option' );
 }
 
 /**
@@ -365,6 +367,24 @@ function wpsc_add_help_tabs() {
 		) );
 
 	}
+}
+
+/**
+ * This function allows change in number of purchase logs shown on Sales Log (Screen Options).
+ *
+ * @since 3.8.14.2
+ * @access public
+ *
+ * @uses add_screen_option()
+ */
+function wpsc_add_purchase_logs_screen_option() {
+
+	// setup Screen Option for purchase logs per page
+	add_screen_option ( 'per_page', array(
+		'label'		=> __( 'Sales Orders', 'wpsc' ),
+		'default'	=> 20,
+		'option'	=> 'wpsc_purchases_per_page'
+	) );
 }
 
 /**

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -20,6 +20,9 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 
 	public function __construct( $args = array() ) {
 		$args['plural'] = 'purchase-logs';
+
+		$this->set_per_page( $this->set_purchase_logs_per_page_by_user() );
+
 		parent::__construct( $args );
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX )
@@ -46,6 +49,31 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		$this->views = false;
 	}
 
+	/**
+	 * This function changes the number of purchase logs shown on Sales Log (Screen Options) based
+	 * on the user meta (if set).
+	 * Based on an example from http://chrismarslender.com/2012/01/26/wordpress-screen-options-tutorial/
+	 *
+	 * @since 3.8.14.2
+	 * @access private
+	 *
+	 * @uses get_current_user_id()
+	 * @uses get_user_meta()
+	 */
+	private function set_purchase_logs_per_page_by_user() {
+
+		$user = get_current_user_id();
+
+		$per_page = get_user_meta( $user, 'wpsc_purchases_per_page', true );
+		if ( empty ( $per_page ) || $per_page < 1 ) {
+
+			$per_page = 20;
+		}
+
+		return $per_page;
+	}
+
+	// Override the default Purchase Logs Per Page
 	public function set_per_page( $per_page ) {
 		$this->per_page = (int) $per_page;
 	}


### PR DESCRIPTION
This patch allows a user to set the number of items to show on the Sales Log page. (Yay!)
