### PR TITLE
Initialize row count changed variable

### DIFF
--- a/wpsc-includes/wpsc-meta-visitor.php
+++ b/wpsc-includes/wpsc-meta-visitor.php
@@ -434,6 +434,9 @@ function wpsc_delete_visitor( $visitor_id ) {
 		return false;
 	}
 
+	// initialize row count changed
+	$result = 0;
+
 	$ok_to_delete_visitor = ! ( wpsc_visitor_has_purchases( $visitor_id )
 									&& wpsc_visitor_post_count( $visitor_id )
 										&& wpsc_visitor_comment_count( $visitor_id ) );


### PR DESCRIPTION
It is checked on function return, initialize to avoid php warning/error

Closes issue #1454
