### PR TITLE
Purchase Log page should display details by default if ID provided.

### DIFF
--- a/wpsc-admin/display-sales-logs.php
+++ b/wpsc-admin/display-sales-logs.php
@@ -25,6 +25,9 @@ class WPSC_Purchase_Log_Page {
 		if ( isset( $_REQUEST['c'] ) && method_exists( $this, 'controller_' . $_REQUEST['c'] ) ) {
 			$controller = $_REQUEST['c'];
 			$controller_method = 'controller_' . $controller;
+		} elseif ( isset( $_REQUEST['id'] ) && is_numeric( $_REQUEST['id'] ) ) {
+			$controller = 'item_details';
+			$controller_method = 'controller_item_details';
 		}
 
 		$this->$controller_method();


### PR DESCRIPTION
Just some sense checking as to how the purchase log page should be displayed if no "c" parameter is passed in the URL. Do see why the "c" parameter should be required in URL for the default display?

Just stumbled across this while working on Purchase Log Action API.

Related to #1445
