### PR TITLE
Properly show Gateway name in admin report

### DIFF
--- a/wpsc-includes/purchase-log-notification.class.php
+++ b/wpsc-includes/purchase-log-notification.class.php
@@ -48,7 +48,7 @@ abstract class WPSC_Purchase_Log_Notification {
 			'coupon_code'     => $this->purchase_log->get( 'discount_data'   ),
 			'transaction_id'  => $this->purchase_log->get( 'transactid'      ),
 			'purchase_log_id' => $this->purchase_log->get( 'id'              ),
-			'payment_method'  => $this->purchase_log->get( 'gateway'         ),
+			'payment_method'  => $this->purchase_log->get( 'gateway_name'    ),
 			'shipping_method' => $this->purchase_log->get( 'shipping_method' ),
 			'shipping_option' => $this->purchase_log->get( 'shipping_option' ),
 			'discount_amount' => $discount,


### PR DESCRIPTION
It was showing "internal name", i believe showing the Display name is best.
It used to show it like that until this commit : https://github.com/wp-e-commerce/WP-e-Commerce/commit/2307c37de20a6fb8f9c06c1badeb41c79d842f8b
