### PR TITLE
Applies the_content filter to process the post_content using installed hooks

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/page.php
+++ b/wpsc-components/theme-engine-v1/helpers/page.php
@@ -635,7 +635,12 @@ function wpsc_the_category_title( $title='', $id='' ){
 
 //handles replacing the tags in the pages
 function wpsc_products_page( $content = '' ) {
-	global $wpdb, $wp_query, $wpsc_query, $wpsc_query_vars, $_wpsc_is_in_custom_loop;
+
+	/* prevent recursively including of the product page, see wpsc_enable_page_filters() */
+	remove_filter( 'the_content', 'wpsc_products_page', 1 );
+
+	global $wp_query, $wpsc_query, $_wpsc_is_in_custom_loop;
+
 	$output = '';
 	if ( ! in_the_loop() )
 		return $content;

--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -146,10 +146,12 @@ function wpsc_the_product_title( $post = 0 ) {
 
 /**
  * wpsc product description function
+ * @uses the_content Applies the filter to process the post_content using installed hooks
  * @return string - the product description
  */
 function wpsc_the_product_description() {
 	$content = get_the_content( __( 'Read the rest of this entry &raquo;', 'wpsc' ) );
+	$content = apply_filters( 'the_content', $content );
 	return do_shortcode( wpautop( $content,1 ) );
 }
 


### PR DESCRIPTION
Addresses issue #1507 where WordPress "the_content" filter actions are being overwritten on single product pages 
