### PR TITLE
Use wpsc_the_product_description in google product feed

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -150,7 +150,18 @@ function wpsc_the_product_title( $post = 0 ) {
  */
 function wpsc_the_product_description() {
 	$content = get_the_content( __( 'Read the rest of this entry &raquo;', 'wpsc' ) );
-	return do_shortcode( wpautop( $content,1 ) );
+
+	/*
+	* Filter the text that decribes the product
+	*
+	* @since 3.8.14.2
+	*
+	* @param string $content Text to display for the product description
+	*
+	*/
+	$content = apply_filters( 'wpsc_the_product_description', $content );
+
+	return do_shortcode( wpautop( $content, 1 ) );
 }
 
 /**

--- a/wpsc-includes/productfeed.php
+++ b/wpsc-includes/productfeed.php
@@ -92,7 +92,7 @@ function wpsc_generate_product_feed() {
 			}
 			echo "      <title><![CDATA[".get_the_title()."]]></title>\n\r";
 			echo "      <link>$purchase_link</link>\n\r";
-			echo "      <description><![CDATA[".apply_filters ('the_content', get_the_content())."]]></description>\n\r";
+			echo "      <description><![CDATA[". wpsc_the_product_description() ."]]></description>\n\r";
 			echo "      <guid>$purchase_link</guid>\n\r";
 
 			$image_link = wpsc_the_product_thumbnail() ;
@@ -192,7 +192,8 @@ function wpsc_generate_product_feed() {
 
 				if ( ! $done_weight ) {
 					$wpsc_product_meta = get_product_meta( $post->ID, 'product_metadata',true );
-					$weight = apply_filters ( 'wpsc_google_shipping_weight', $wpsc_product_meta['weight'], $post->ID );
+					$weight = isset( $wpsc_product_meta['weight'] ) ? $wpsc_product_meta['weight'] : 0;
+					$weight = apply_filters ( 'wpsc_google_shipping_weight', $weight, $post->ID );
 					if ( $weight && is_numeric ( $weight ) && $weight > 0 ) {
 						echo "<g:shipping_weight>$weight pounds</g:shipping_weight>";
 					}


### PR DESCRIPTION
* Add filter to wpsc_the_product_description filter to give plugins the opportunity to filter product descriptions
* Check the the weight meta value exists before using it in the google product feed
* Use the wpsc_the_product_description function to get the product description for the Google product feed  so that the product description in the feed matches the product description on the product page