### PR TITLE
wpsc_product_variation_price_from() should accept and use a 'no_decimals' argument.

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -631,7 +631,7 @@ function wpsc_the_product_price( $no_decimals = false, $only_normal_price = fals
 				$price = $special_price;
 		}
 
-		if ( true == $no_decimals ) {
+		if ( $no_decimals ) {
 			$price = explode( ".", $price );
 			$price = array_shift( $price );
 		}

--- a/wpsc-includes/product-template.php
+++ b/wpsc-includes/product-template.php
@@ -88,7 +88,7 @@ function wpsc_product_variation_price_from( $product_id, $args = null ) {
 				$price = $special_price;
 		}
 
-		if ( true == $args['no_decimals'] ) {
+		if ( $args['no_decimals'] ) {
 			$price = explode( '.', $price );
 			$price = array_shift( $price );
 		}


### PR DESCRIPTION
For issue #1432 

Allows wpsc_product_variation_price_from() to accept a 'no_decimals' argument and passes through the 'no_decimals' value from wpsc_the_product_price().

Please test.
