### PR TITLE
PR for a handful of translations and labels spacing affecting few theme files

### DIFF
--- a/wpsc-theme/wpsc-grid_view.php
+++ b/wpsc-theme/wpsc-grid_view.php
@@ -87,7 +87,7 @@ $image_height = get_option('product_image_height');
                         	<div class="price_container">
                         		<?php wpsc_the_product_price_display( array( 'output_you_save' => false ) ); ?>
 								<?php if(wpsc_show_pnp()) : ?>
-									<p class="pricedisplay"><?php _e('Shipping', 'wpsc'); ?>:<span class="pp_price"><?php echo wpsc_product_postage_and_packaging(); ?></span></p>
+									<p class="pricedisplay"><?php _e('Shipping', 'wpsc'); ?>:<span class="pp_price"><?php echo ' ' . wpsc_product_postage_and_packaging(); ?></span></p>
 								<?php endif; ?>
 							</div><!--close price_container-->
 						<?php if(get_option('display_moredetails') == 1) : ?>

--- a/wpsc-theme/wpsc-products_page.php
+++ b/wpsc-theme/wpsc-products_page.php
@@ -179,7 +179,7 @@ $image_width = get_option('product_image_width');
                                     <?php endif; ?>
 
 									<?php if(wpsc_show_pnp()) : ?>
-										<p class="pricedisplay"><?php _e('Shipping', 'wpsc'); ?>:<span class="pp_price"><?php echo wpsc_product_postage_and_packaging(); ?></span></p>
+										<p class="pricedisplay"><?php _e('Shipping', 'wpsc'); ?>:<span class="pp_price"><?php echo ' ' . wpsc_product_postage_and_packaging(); ?></span></p>
 									<?php endif; ?>
 								<?php endif; ?>
 							</div><!--close wpsc_product_price-->

--- a/wpsc-theme/wpsc-shopping_cart_page.php
+++ b/wpsc-theme/wpsc-shopping_cart_page.php
@@ -208,7 +208,7 @@ endif;
       <table class="productcart">
          <tr class="total_price total_tax">
             <td colspan="3">
-               <?php echo wpsc_display_tax_label(true); ?>
+               <?php echo wpsc_display_tax_label(true) . ':'; ?>
             </td>
             <td colspan="2">
                <span id="checkout_tax" class="pricedisplay checkout-tax"><?php echo wpsc_cart_tax(); ?></span>
@@ -247,7 +247,7 @@ endif;
       <?php if(wpsc_uses_shipping()) : ?>
 	      <tr class="total_price total_shipping">
 	         <td class='wpsc_totals'>
-	            <?php _e('Total Shipping:', 'wpsc'); ?>
+	            <?php echo __('Total Shipping', 'wpsc') . ':'; ?>
 	         </td>
 	         <td class='wpsc_totals'>
 	            <span id="checkout_shipping" class="pricedisplay checkout-shipping"><?php echo wpsc_cart_shipping(); ?></span>
@@ -270,7 +270,7 @@ endif;
 
    <tr class='total_price'>
       <td class='wpsc_totals'>
-      <?php _e('Total Price:', 'wpsc'); ?>
+      <?php echo __('Total Price', 'wpsc') . ':'; ?>
       </td>
       <td class='wpsc_totals'>
          <span id='checkout_total' class="pricedisplay checkout-total"><?php echo wpsc_cart_total(); ?></span>

--- a/wpsc-theme/wpsc-single_product.php
+++ b/wpsc-theme/wpsc-single_product.php
@@ -145,7 +145,7 @@
 	                                    <?php echo wpsc_display_product_multicurrency(); ?>
                                     <?php endif; ?>
 									<?php if(wpsc_show_pnp()) : ?>
-										<p class="pricedisplay"><?php _e('Shipping', 'wpsc'); ?>:<span class="pp_price"><?php echo wpsc_product_postage_and_packaging(); ?></span></p>
+										<p class="pricedisplay"><?php _e('Shipping', 'wpsc'); ?>:<span class="pp_price"><?php echo ' ' . wpsc_product_postage_and_packaging(); ?></span></p>
 									<?php endif; ?>
 								<?php endif; ?>
 							</div><!--close wpsc_product_price-->


### PR DESCRIPTION
I'm providing minor theme files modifications that will allow for few translations to be found, and proper spacing to be maintained for a handful of labels being displayed.

The translations for these labels do not include colons, so the direct inclusion of them within the text makes it impossible for them to be found inside the translation files.

The spacing is needed in order to separate information from labels terminated with colons.

Solves issue #1573 
