### PR TITLE
Nonce save product to prevent Quick Edit overridden saved values

### DIFF
--- a/wpsc-admin/includes/display-items-functions.php
+++ b/wpsc-admin/includes/display-items-functions.php
@@ -855,6 +855,8 @@ function wpsc_product_external_link_forms() {
 	<em><?php esc_html_e( 'This option overrides the "Buy Now" and "Add to Cart" buttons, replacing them with the link you describe here.', 'wpsc' ); ?></em>
 	<?php
 
+	wp_nonce_field( 'update', 'wpsc_product_external_link_nonce' );
+
 }
 
 function wpsc_additional_desc() {

--- a/wpsc-admin/includes/product-functions.php
+++ b/wpsc-admin/includes/product-functions.php
@@ -127,6 +127,18 @@ function wpsc_admin_submit_product( $post_ID, $post ) {
 			$post_data['meta']['_wpsc_product_metadata']['wpec_taxes_taxable_amount']
 		);
 
+	// External Link Options
+	if ( isset( $_POST['wpsc_product_external_link_nonce'] ) && wp_verify_nonce( $_POST['wpsc_product_external_link_nonce'], 'update' ) ) {
+
+		// Parse post meta to ensure default values
+		$post_data['meta']['_wpsc_product_metadata'] = wp_parse_args( $post_data['meta']['_wpsc_product_metadata'], array(
+			'external_link'        => '',
+			'external_link_text'   => '',
+			'external_link_target' => ''
+		) );
+
+	}
+
 	// Advanced Options
 	if ( isset( $_POST['wpsc_product_personalization_nonce'] ) && wp_verify_nonce( $_POST['wpsc_product_personalization_nonce'], 'update' ) ) {
 
@@ -139,21 +151,20 @@ function wpsc_admin_submit_product( $post_ID, $post ) {
 		$post_data['meta']['_wpsc_product_metadata']['engraved'] = absint( (bool) $post_data['meta']['_wpsc_product_metadata']['engraved'] );
 		$post_data['meta']['_wpsc_product_metadata']['can_have_uploaded_image'] = absint( (bool) $post_data['meta']['_wpsc_product_metadata']['can_have_uploaded_image'] );
 
-	} else {
-
-		// Use existing personalization values if not submitted
-		$current_product_meta = wp_parse_args( get_product_meta( $product_id, 'product_metadata', true ), array(
-			'engraved'                => 0,
-			'can_have_uploaded_image' => 0
-		) );
-
-		$post_data['meta']['_wpsc_product_metadata']['engraved'] = $current_product_meta['engraved'];
-		$post_data['meta']['_wpsc_product_metadata']['can_have_uploaded_image'] = $current_product_meta['can_have_uploaded_image'];
-
 	}
 
 	if ( ! isset($post_data['meta']['_wpsc_product_metadata']['google_prohibited'])) $post_data['meta']['_wpsc_product_metadata']['google_prohibited'] = '';
 	$post_data['meta']['_wpsc_product_metadata']['google_prohibited'] = (int)(bool)$post_data['meta']['_wpsc_product_metadata']['google_prohibited'];
+
+	// Fill in any missing product meta values with existing values.
+	$default_meta_values = wp_parse_args( get_product_meta( $product_id, 'product_metadata', true ), array(
+		'external_link'        => '',
+		'external_link_text'   => '',
+		'external_link_target' => '',
+		'engraved'                => 0,
+		'can_have_uploaded_image' => 0
+	) );
+	$post_data['meta']['_wpsc_product_metadata'] = wp_parse_args( $post_data['meta']['_wpsc_product_metadata'], $default_meta_values );
 
 	$post_data['files'] = $_FILES;
 


### PR DESCRIPTION
This will fix #1488 (personalization options) and also overwriting of external links by quick save, but on further investigation it looks like other fields are overwritten too.

This PR can be merged as is and I will do a more comprehensive review of noncing and Quick Save.
