### PR TITLE
Fix wpsc_you_save in wpsc_the_product_price_display 

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -1652,8 +1652,7 @@ function wpsc_the_product_price_display( $args = array() ) {
 	// if the product has no variations, these amounts are straight forward...
 	$old_price           = wpsc_product_normal_price( $id );
 	$current_price       = wpsc_the_product_price( false, false, $id );
-	$you_save            = wpsc_you_save( 'type=amount' ) . '! (' . wpsc_you_save() . '%)';
-	$you_save_percentage = wpsc_you_save();
+	$you_save            = wpsc_you_save( array( 'type' => 'amount', 'product_id' => $id, ) );
 
 	$show_old_price = $show_you_save = wpsc_product_on_special( $id );
 


### PR DESCRIPTION
Calls to wpsc_you_save in wpsc_the_product_price_display pass the product id as a parameter, let's the price be calculated for an arbitrary product id passed as a parameter rather than always calculating the price for the current product in the loop.

Removed unnecessary calls to wpsc_you_save whose results where being overwritten by later processing
