### PR TITLE
Adjusted the check for when a thumbnail needs to be regenerated.

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -990,6 +990,13 @@ function wpsc_check_display_type(){
  *
  * @return string - the URL to the thumbnail image
  */
+/**
+ * wpsc product thumbnail function
+ *
+ * Show the thumbnail image for the product
+ *
+ * @return string - the URL to the thumbnail image
+ */
 function wpsc_the_product_thumbnail( $width = null, $height = null, $product_id = 0, $page = false ) {
 	$thumbnail = false;
 	$display = wpsc_check_display_type();
@@ -1035,14 +1042,22 @@ function wpsc_the_product_thumbnail( $width = null, $height = null, $product_id 
 
 			if ( ! $custom_thumbnail ) {
 				$custom_thumbnail = 'medium-single-product';
+			}
+
+			$src = wp_get_attachment_image_src( $thumbnail_id, $custom_thumbnail );
+
+			if ( ! $src ) {
+				$custom_thumbnail = 'medium-single-product';
 				$current_size = image_get_intermediate_size( $thumbnail_id, $custom_thumbnail );
 				$settings_width  = get_option( 'single_view_image_width' );
 				$settings_height = get_option( 'single_view_image_height' );
 
-				if ( ! $current_size || ( $current_size['width'] != $settings_width && $current_size['height'] != $settings_height ) )
+				if ( ! $current_size || ( $current_size['width'] != $settings_width && $current_size['height'] != $settings_height ) ) {
 					_wpsc_regenerate_thumbnail_size( $thumbnail_id, $custom_thumbnail );
+				}
+
+				$src = wp_get_attachment_image_src( $thumbnail_id, $custom_thumbnail );
 			}
-			$src = wp_get_attachment_image_src( $thumbnail_id, $custom_thumbnail );
 
 			if ( ! empty( $src ) && is_string( $src[0] ) )
 				$thumbnail = $src[0];


### PR DESCRIPTION
The previous check  appeared to be using the presence of a WPeC specific meta value as an indicator that an image of the correct proportions is available. If the meta value was not present then all of the image sizes for the object would be regenerated.  This is a time consuming and resource intensive operation. After the image was regenerated the WPeC specific meta value was not being set.  That means that the next time through the function the intermediate images sizes would be regenerated again, and again ....

There also appear to be frequent are conditions when the image of the correct size is available, but the meta value is not set.

The code was modified to have two distinct checks. Is the special meta key available, if not use the default value. Second check is if the image of the desired size, from the meta key or the default value for the meta key, is already available.
