### PR TITLE
Fix for #1151

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -1668,8 +1668,8 @@ function wpsc_the_product_price_display( $args = array() ) {
 	// if the product has no variations, these amounts are straight forward...
 	$old_price           = wpsc_product_normal_price( $id );
 	$current_price       = wpsc_the_product_price( false, false, $id );
-	$you_save            = wpsc_you_save( 'type=amount' ) . '! (' . wpsc_you_save() . '%)';
-	$you_save_percentage = wpsc_you_save();
+	$you_save            = wpsc_you_save( 'type=amount&product_id=' . $id ) . '! (' . wpsc_you_save( 'product_id=' . $id ) . '%)';
+	$you_save_percentage = wpsc_you_save( 'product_id=' . $id );
 
 	$show_old_price = $show_you_save = wpsc_product_on_special( $id );
 


### PR DESCRIPTION
if product id is passed as a parameter to wpsc_the_product_price_display then pass it to other functions

fix #1551
