### PR TITLE
Default the shipping rate only if there is only one rate available.

### DIFF
--- a/wpsc-includes/cart.class.php
+++ b/wpsc-includes/cart.class.php
@@ -1218,19 +1218,16 @@ class wpsc_cart {
 	}
 
 	/**
-	 * Set the lowest shipping rate as the default.
+	 * If there is only one quote, set it as the default.
 	 *
 	 * @param string     $selected_option  The currently selected rate.
 	 * @param array      $shipping_quotes  Array of all available shipping quotes.
 	 * @param WPSC_Cart  $wpsc_cart        The WPSC_Cart object.
 	 */
 	function set_default_shipping_quote( $selected_option, $shipping_quotes, $wpsc_cart ) {
-		$min = null;
-		foreach ( $shipping_quotes as $key => $value ) {
-			if ( is_null( $min ) || $value < $min ) {
-				$min = $value;
-				$selected_option = $key;
-			}
+		if ( count( $shipping_quotes ) == 1 ) {
+			reset( $shipping_quotes );
+			$selected_option = key( $shipping_quotes );
 		}
 		return $selected_option;
 	}


### PR DESCRIPTION
There were a number of discussions on #1588 that indicated that defaulting in the lowest rate wasn't the agreed behaviour. This PR fixes #1329 by defaulting the shipping choice if there is only one choice available, but not providing a default in all other cases. 

Users who wish to default the lowest can do so using the filters supplied (Or using the plugin I'll push to wp.org shortly!)
