### PR TITLE
Don't query the database directly to get product custom meta

### DIFF
--- a/wpsc-includes/meta.functions.php
+++ b/wpsc-includes/meta.functions.php
@@ -224,7 +224,7 @@ class wpsc_custom_meta {
 			$meta_values = get_post_meta( $post_id );
 
 			foreach ( $meta_values as $key => $values ) {
-				if ( ! is_protected_meta( $key ) ) {
+				if ( ! is_protected_meta( $key,  'wpsc-product' ) ) {
 					if ( is_array( $values ) ) {
 						foreach ( $values as $value ) {
 							$cleaned_metas[] = array( 'meta_key' => $key, 'meta_value' => $value );


### PR DESCRIPTION
Instead get the post meta, and filter out unwanted values.

Note: the meta_id and post_id are no longer in the meta values array elements.
