### PR TITLE
Dont make variations database requests calls when variations aren't being used

### DIFF
--- a/wpsc-core/wpsc-functions.php
+++ b/wpsc-core/wpsc-functions.php
@@ -674,13 +674,20 @@ function wpsc_update_permalink_slugs() {
  * @return stdObject[]
  */
 function wpsc_get_product_terms( $product_id, $tax, $field = '' ) {
+
 	$terms = get_the_terms( $product_id, $tax );
+	// if, albeit for some bizarre reason, the call returns a WordPress error lets behave as if there weren't any terms
+	if ( is_wp_error( $terms ) ) {
+		$terms = false;
+	}
 
-	if ( ! $terms )
+	if ( ! $terms ) {
 		$terms = array();
+	}
 
-	if ( $field )
+	if ( $field ) {
 		$terms = wp_list_pluck( $terms, $field );
+	}
 
 	// remove the redundant array keys, could cause issues in loops with iterator
 	$terms = array_values( $terms );

--- a/wpsc-includes/product-template.php
+++ b/wpsc-includes/product-template.php
@@ -269,6 +269,10 @@ function wpsc_product_has_children( $id, $exclude_unpublished = true ){
 function wpsc_product_has_variations( $id = 0 ) {
 	static $has_variations = array();
 
+	if ( ! wpsc_variations::variations_are_being_used() ) {
+		return false;
+	}
+
 	if ( ! $id )
 		$id = get_the_ID();
 

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -34,7 +34,6 @@ class wpsc_variations {
 			$variations_are_being_used = intval( get_option( self::VARIATIONS_BEING_USED_OPTION_NAME, 1 ) );
 		}
 
-		error_log( __CLASS__ . '::' . __FUNCTION__ . ' ' . ( $variations_are_being_used ? 'true' : 'false' ) );
 		return (bool) $variations_are_being_used;
 	}
 
@@ -117,7 +116,7 @@ class wpsc_variations {
 
 		return $this->variation_group;
 	}
-	
+
 	function the_variation_group() {
 		$this->variation_group = $this->next_variation_group();
 		$this->get_variations();
@@ -365,7 +364,6 @@ if ( is_admin() ) {
 		if ( $old_variations_being_used != $new_variations_are_being_used ) {
 			delete_option( wpsc_variations::VARIATIONS_BEING_USED_OPTION_NAME );
 			add_option( wpsc_variations::VARIATIONS_BEING_USED_OPTION_NAME, $new_variations_are_being_used, null, true );
-			error_log(  __FUNCTION__ . ' updating variations being used option ' . ( $new_variations_are_being_used ? 'true' : 'false' ) );
 		}
 	}
 


### PR DESCRIPTION
Add check to see if variations are defined and used, when they are not defined and used don't make calls through WordPress for variation terms unless working inside the admin area.  Avoids lots of small empty queries.

Add checks to variation class to avoid walking off the end of internal arrays
