### PR TITLE
Fix wpsc_refresh_cart_items() not refreshing cart items.

### DIFF
--- a/wpsc-includes/cart.class.php
+++ b/wpsc-includes/cart.class.php
@@ -118,6 +118,8 @@ class wpsc_cart {
 
 	public function update_location() {
 
+		$this->clear_cache();
+
 		$delivery_country = wpsc_get_customer_meta( 'shippingcountry' );
 		$billing_country  = wpsc_get_customer_meta( 'billingcountry'  );
 		$delivery_region  = wpsc_get_customer_meta( 'shippingregion'  );


### PR DESCRIPTION
For issue #1611

Check if $wpsc_cart->cart_items is an array (rather than object) before looping through cart items.
