### PR TITLE
Default purchase log email address to WordPress admin email address.

### DIFF
--- a/wpsc-core/wpsc-installer.php
+++ b/wpsc-core/wpsc-installer.php
@@ -242,7 +242,7 @@ function wpsc_install() {
     add_option( 'shipwire', '0', '', 'no' );
     add_option( 'shipwire_test_server', '0', '', 'no' );
 
-	add_option( 'purch_log_email', '', '', 'no' );
+	add_option( 'purch_log_email', get_option( 'admin_email', '' ), '', 'no' );
 	add_option( 'return_email', '', '', 'no' );
 	add_option( 'terms_and_conditions', '', '', 'no' );
 


### PR DESCRIPTION
Defaults the purchase log email address on install to the same as the WordPress admin email address. Fixes #1639 
