### PR TITLE
Fixes several issues with weight rate shipping

### DIFF
--- a/wpsc-shipping/weightrate.php
+++ b/wpsc-shipping/weightrate.php
@@ -190,9 +190,7 @@ class weightrate {
 
 		global $wpsc_cart;
 
-		$unit_price = $cart_item->unit_price;
 		$quantity = $cart_item->quantity;
-		$weight = $cart_item->weight;
 		$product_id = $cart_item->product_id;
 
 		$uses_billing_address = false;


### PR DESCRIPTION
This PR includes a few changes, hopefully chunked into easy to follow commits. 
- A bit of a code spring clean (Not exhaustive)
- Fix an issue where % based rates wouldn't be calculated properly
- Fix an issue where no rate could be save where the weight boundary was 0
- Remove some unused code, variables, globals
