### PR TITLE
Added 'wpsc_duplicate_product_attachment' filter

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -1505,7 +1505,7 @@ function wpsc_duplicate_children( $old_parent_id, $new_parent_id ) {
  */
 function wpsc_duplicate_product_image_process( $child_post, $new_parent_id ) {
 
-	if ( 'attachment' == get_post_type( $child_post ) ) {
+	if ( 'attachment' == get_post_type( $child_post ) && apply_filters( 'wpsc_duplicate_product_attachment', true, $child_post ) ) {
 
 		$file = wp_get_attachment_url( $child_post->ID );
 


### PR DESCRIPTION
For #1661

This can be used to prevent duplicating attachment files when duplicating a product.

The filter works on a per attachment basis so you could use the filter to only allow the attachment to be copied if it is the featured image or is a certain mime type for example.

This filter just relates to the attachment files attached to the product (post). It currently doesn't provide control over product image IDs stored in meta such as the featured image and '_wpsc_product_gallery'.

I will look at addressing this in a future release, possibly via 'wpsc_duplicate_product_image' and  'wpsc_duplicate_product_featured_image' filters.

Currently, if you duplicate a product with a featured image but use the 'wpsc_duplicate_product_attachment' filter to opt not to duplicate the attachment files, the featured image meta will still be copied and will reference the featured image ID of the product being duplicated.
