### PR TITLE
Provide purchase log bulk actions for statuses added via filter.

### DIFF
--- a/wpsc-admin/display-sales-logs.php
+++ b/wpsc-admin/display-sales-logs.php
@@ -409,7 +409,7 @@ class WPSC_Purchase_Log_Page {
 		}
 
 		// change status actions
-		if ( is_numeric( $current_action ) && $current_action < 7 && ! empty( $_REQUEST['post'] ) ) {
+		if ( is_numeric( $current_action ) && ! empty( $_REQUEST['post'] ) ) {
 
 			foreach ( $_REQUEST['post'] as $id )
 				wpsc_purchlog_edit_status( $id, $current_action );

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -283,8 +283,10 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		$view_labels = array();
 		foreach ( $wpsc_purchlog_statuses as $status ) {
 			if ( ! empty( $status['view_label'] ) ) {
+				// The status provides a view label i18n _nx_noop-able object.
 				$view_labels[$status['order']]['view_label'] = $status['view_label'];
 			} else {
+				// The status doesn't provide a view label i18n string. Use a generic one.
 				$view_labels[$status['order']]['view_label'] = _nx_noop(
 					'%s <span class="count">(%d)</span>',
 					'%s <span class="count">(%d)</span>',

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -568,15 +568,9 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		// Standard actions.
 		$actions = array(
 			'delete' => _x( 'Delete', 'bulk action', 'wpsc' ),
-			'1'      => __( 'Incomplete Sale', 'wpsc' ),
-			'2'      => __( 'Order Received', 'wpsc' ),
-			'3'      => __( 'Accepted Payment', 'wpsc' ),
-			'4'      => __( 'Job Dispatched', 'wpsc' ),
-			'5'      => __( 'Closed Order', 'wpsc' ),
-			'6'      => __( 'Payment Declined', 'wpsc' ),
 		);
 
-		// Loop through all statuses and register bulk actions for any other statuses.
+		// Loop through all statuses and register bulk actions for them.
 		foreach ( $wpsc_purchlog_statuses as $status ) {
 			if ( in_array( $status['order'], array_keys( $actions ) ) ) {
 				continue;

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -549,9 +549,14 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 	}
 
 	public function get_bulk_actions() {
-		if ( ! $this->bulk_actions )
-			return array();
 
+		global $wpsc_purchlog_statuses;
+
+		if ( ! $this->bulk_actions ) {
+			return array();
+		}
+
+		// Standard actions.
 		$actions = array(
 			'delete' => _x( 'Delete', 'bulk action', 'wpsc' ),
 			'1'      => __( 'Incomplete Sale', 'wpsc' ),
@@ -561,7 +566,16 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 			'5'      => __( 'Closed Order', 'wpsc' ),
 			'6'      => __( 'Payment Declined', 'wpsc' ),
 		);
-		return $actions;
+
+		// Loop through all statuses and register bulk actions for any other statuses.
+		foreach ( $wpsc_purchlog_statuses as $status ) {
+			if ( in_array( $status['order'], array_keys( $actions ) ) ) {
+				continue;
+			}
+			$actions[$status['order']] = $status['label'];
+		}
+
+		return apply_filters( 'wpsc_manage_purchase_logs_bulk_actions', $actions );
 	}
 
 	public function search_box( $text, $input_id ) {

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -578,6 +578,13 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 			$actions[$status['order']] = $status['label'];
 		}
 
+		/**
+		 * Filter the available bulk actions on the purchase log listing screen.
+		 *
+		 * @since 4.0
+		 *
+		 * @param array $actions The bulk actions currently defined.
+		 */
 		return apply_filters( 'wpsc_manage_purchase_logs_bulk_actions', $actions );
 	}
 

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -325,8 +325,9 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		);
 
 		foreach ( $statuses as $status => $count ) {
-			if ( ! isset( $view_labels[$status] ) )
+			if ( ! isset( $view_labels[$status] ) ) {
 				continue;
+			}
 			$text = sprintf(
 				$view_labels[$status]['label'],
 				$view_labels[$status]['status_label'],

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -577,15 +577,7 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 			}
 			$actions[$status['order']] = $status['label'];
 		}
-
-		/**
-		 * Filter the available bulk actions on the purchase log listing screen.
-		 *
-		 * @since 4.0
-		 *
-		 * @param array $actions The bulk actions currently defined.
-		 */
-		return apply_filters( 'wpsc_manage_purchase_logs_bulk_actions', $actions );
+		return $actions;
 	}
 
 	public function search_box( $text, $input_id ) {

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -548,6 +548,15 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		<?php
 	}
 
+	/**
+	 * Provide bulk actions for sales logs.
+	 *
+	 * Generates bulk actions for standard order statuses. Also generates a "delete" bulk action,
+	 * and actions for any additional statuses that have been registered via the
+	 * wpsc_set_purchlog_statuses filter.
+	 *
+	 * @return array Array of bulk actions available.
+	 */
 	public function get_bulk_actions() {
 
 		global $wpsc_purchlog_statuses;

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -269,6 +269,13 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		return $months;
 	}
 
+	/**
+	 * Get the sub-views of the list table.
+	 *
+	 * Allows user to limit the list to orders in a particular status.
+	 *
+	 * @return array The available view links.
+	 */
 	public function get_views() {
 		global $wpdb;
 

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -282,10 +282,17 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 
 		$view_labels = array();
 		foreach ( $wpsc_purchlog_statuses as $status ) {
-			$view_labels[$status['order']]['label']        = _x( '%s <span class="count">(%d)</span>', 'Links to filter purchase log list by status. String is the status name, number is the count of purchase logs in that status.', 'wpsc' );
-			$view_labels[$status['order']]['status_label'] = $status['label'];
+			if ( ! empty( $status['view_label'] ) ) {
+				$view_labels[$status['order']] = $status['view_label'];
+			} else {
+				$view_labels[$status['order']] = _nx_noop(
+					sprintf( '%s <span class="count">(%%d)</span>', $status['label'] ),
+					sprintf( '%s <span class="count">(%%d)</span>', $status['label'] ),
+					'Purchase log view links for custom status with no explicit translation.',
+					'wpsc'
+				);
+			}
 		}
-
 		$sql = 'SELECT DISTINCT processed, COUNT(*) AS count FROM ' . WPSC_TABLE_PURCHASE_LOGS . ' GROUP BY processed ORDER BY processed';
 		$results = $wpdb->get_results( $sql );
 		$statuses = array();
@@ -329,8 +336,7 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 				continue;
 			}
 			$text = sprintf(
-				$view_labels[$status]['label'],
-				$view_labels[$status]['status_label'],
+				translate_nooped_plural( $view_labels[$status], $count, 'wpsc' ),
 				number_format_i18n( $count )
 			);
 			$href = add_query_arg( 'status', $status );

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -283,14 +283,15 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 		$view_labels = array();
 		foreach ( $wpsc_purchlog_statuses as $status ) {
 			if ( ! empty( $status['view_label'] ) ) {
-				$view_labels[$status['order']] = $status['view_label'];
+				$view_labels[$status['order']]['view_label'] = $status['view_label'];
 			} else {
-				$view_labels[$status['order']] = _nx_noop(
-					sprintf( '%s <span class="count">(%%d)</span>', $status['label'] ),
-					sprintf( '%s <span class="count">(%%d)</span>', $status['label'] ),
+				$view_labels[$status['order']]['view_label'] = _nx_noop(
+					'%s <span class="count">(%d)</span>',
+					'%s <span class="count">(%d)</span>',
 					'Purchase log view links for custom status with no explicit translation.',
 					'wpsc'
 				);
+				$view_labels[$status['order']]['label'] = $status['label'];
 			}
 		}
 		$sql = 'SELECT DISTINCT processed, COUNT(*) AS count FROM ' . WPSC_TABLE_PURCHASE_LOGS . ' GROUP BY processed ORDER BY processed';
@@ -330,15 +331,24 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 				$all_text
 			),
 		);
-
 		foreach ( $statuses as $status => $count ) {
 			if ( ! isset( $view_labels[$status] ) ) {
 				continue;
 			}
-			$text = sprintf(
-				translate_nooped_plural( $view_labels[$status], $count, 'wpsc' ),
-				number_format_i18n( $count )
-			);
+			if ( empty( $view_labels[$status]['label'] ) ) {
+				// This translation needs only the quantity dropping in.
+				$text = sprintf(
+					translate_nooped_plural( $view_labels[$status]['view_label'], $count, 'wpsc' ),
+					number_format_i18n( $count )
+				);
+			} else {
+				// This translation needs the status label, and quantity dropping in.
+				$text = sprintf(
+					translate_nooped_plural( $view_labels[$status]['view_label'], $count, 'wpsc' ),
+					$view_labels[$status]['label'],
+					number_format_i18n( $count )
+				);
+			}
 			$href = add_query_arg( 'status', $status );
 			$href = remove_query_arg( array(
 				'deleted',

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -577,7 +577,15 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 			}
 			$actions[$status['order']] = $status['label'];
 		}
-		return $actions;
+
+		/**
+		 * Filter the available bulk actions on the purchase log listing screen.
+		 *
+		 * @since 4.0
+		 *
+		 * @param array $actions The bulk actions currently defined.
+		 */
+		return apply_filters( 'wpsc_manage_purchase_logs_bulk_actions', $actions );
 	}
 
 	public function search_box( $text, $input_id ) {

--- a/wpsc-admin/includes/purchase-log-list-table-class.php
+++ b/wpsc-admin/includes/purchase-log-list-table-class.php
@@ -277,18 +277,16 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 	 * @return array The available view links.
 	 */
 	public function get_views() {
-		global $wpdb;
 
-		$view_labels = array(
-			1 => _nx_noop( 'Incomplete <span class="count">(%s)</span>', 'Incomplete <span class="count">(%s)</span>', 'purchase logs' ),
-			2 => _nx_noop( 'Received <span class="count">(%s)</span>'  , 'Received <span class="count">(%s)</span>'  , 'purchase logs' ),
-			3 => _nx_noop( 'Accepted <span class="count">(%s)</span>'  , 'Accepted <span class="count">(%s)</span>'  , 'purchase logs' ),
-			4 => _nx_noop( 'Dispatched <span class="count">(%s)</span>', 'Dispatched <span class="count">(%s)</span>', 'purchase logs' ),
-			5 => _nx_noop( 'Closed <span class="count">(%s)</span>'    , 'Closed <span class="count">(%s)</span>'    , 'purchase logs' ),
-			6 => _nx_noop( 'Declined <span class="count">(%s)</span>'  , 'Declined <span class="count">(%s)</span>'  , 'purchase logs' ),
-		);
+		global $wpdb, $wpsc_purchlog_statuses;
 
-		$sql = "SELECT DISTINCT processed, COUNT(*) AS count FROM " . WPSC_TABLE_PURCHASE_LOGS . " GROUP BY processed ORDER BY processed";
+		$view_labels = array();
+		foreach ( $wpsc_purchlog_statuses as $status ) {
+			$view_labels[$status['order']]['label']        = _x( '%s <span class="count">(%d)</span>', 'Links to filter purchase log list by status. String is the status name, number is the count of purchase logs in that status.', 'wpsc' );
+			$view_labels[$status['order']]['status_label'] = $status['label'];
+		}
+
+		$sql = 'SELECT DISTINCT processed, COUNT(*) AS count FROM ' . WPSC_TABLE_PURCHASE_LOGS . ' GROUP BY processed ORDER BY processed';
 		$results = $wpdb->get_results( $sql );
 		$statuses = array();
 		$total_count = 0;
@@ -297,7 +295,6 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 			foreach ( $results as $status ) {
 				$statuses[$status->processed] = $status->count;
 			}
-
 			$total_count = array_sum( $statuses );
 		}
 
@@ -331,7 +328,8 @@ class WPSC_Purchase_Log_List_Table extends WP_List_Table {
 			if ( ! isset( $view_labels[$status] ) )
 				continue;
 			$text = sprintf(
-				translate_nooped_plural( $view_labels[$status], $count, 'wpsc' ),
+				$view_labels[$status]['label'],
+				$view_labels[$status]['status_label'],
 				number_format_i18n( $count )
 			);
 			$href = add_query_arg( 'status', $status );

--- a/wpsc-core/wpsc-functions.php
+++ b/wpsc-core/wpsc-functions.php
@@ -242,34 +242,70 @@ function wpsc_core_load_purchase_log_statuses() {
 		array(
 			'internalname' => 'incomplete_sale',
 			'label'        => __( 'Incomplete Sale', 'wpsc' ),
+			'view_label'   => _nx_noop(
+				'Incomplete Sale <span class="count">(%d)</span>',
+				'Incomplete Sale <span class="count">(%d)</span>',
+				'Purchase log view links',
+				'wpsc'
+			),
 			'order'        => 1,
 		),
 		array(
 			'internalname' => 'order_received',
 			'label'        => __( 'Order Received', 'wpsc' ),
+			'view_label'   => _nx_noop(
+				'Order Received <span class="count">(%d)</span>',
+				'Order Received <span class="count">(%d)</span>',
+				'Purchase log view links',
+				'wpsc'
+			),
 			'order'        => 2,
 		),
 		array(
 			'internalname'   => 'accepted_payment',
 			'label'          => __( 'Accepted Payment', 'wpsc' ),
+			'view_label'     => _nx_noop(
+				'Accepted Payment <span class="count">(%d)</span>',
+				'Accepted Payment <span class="count">(%d)</span>',
+				'Purchase log view links',
+				'wpsc'
+			),
 			'is_transaction' => true,
 			'order'          => 3,
 		),
 		array(
 			'internalname'   => 'job_dispatched',
 			'label'          => __( 'Job Dispatched', 'wpsc' ),
+			'view_label'     => _nx_noop(
+				'Job Dispatched <span class="count">(%d)</span>',
+				'Job Dispatched <span class="count">(%d)</span>',
+				'Purchase log view links',
+				'wpsc'
+			),
 			'is_transaction' => true,
 			'order'          => 4,
 		),
 		array(
 			'internalname'   => 'closed_order',
 			'label'          => __( 'Closed Order', 'wpsc' ),
+			'view_label'     => _nx_noop(
+				'Closed Order <span class="count">(%d)</span>',
+				'Closed Order <span class="count">(%d)</span>',
+				'Purchase log view links',
+				'wpsc'
+			),
 			'is_transaction' => true,
 			'order'          => 5,
 		),
 		array(
 			'internalname'   => 'declined_payment',
 			'label'          => __( 'Payment Declined', 'wpsc' ),
+			'view_label'     => _nx_noop(
+				'Payment Declined <span class="count">(%d)</span>',
+				'Payment Declined <span class="count">(%d)</span>',
+				'Purchase log view links',
+				'wpsc'
+			),
 			'order'          => 6,
 		),
 	);


### PR DESCRIPTION
This generates bulk actions for non-standard purchase log statuses. This fixes #1723.

Some thoughts on this though:
* Should we document the new filter in the function docblock - or inline a la WP core?
* Any idea why the hardcoded restriction on $current_action was there - am I breaking anything by removing it?
* Should *all* the actions be generated from the global status array?

