### PR TITLE
Do not update upgrade notice options on each request

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -1577,11 +1577,13 @@ function _wpsc_admin_notices_3dot8dot9() {
 	echo '<div id="wpsc-3.8.9-notice" class="error">' . $message . '</div>';
 }
 
-if ( isset( $_REQUEST['dismiss_389_upgrade_notice'] ) || version_compare( WPSC_VERSION, '3.8.10', '>=' ) )
-	update_option( 'wpsc_hide_3.8.9_notices', true );
-
-if ( ! get_option( 'wpsc_hide_3.8.9_notices' ) )
+if ( ! get_option( 'wpsc_hide_3.8.9_notices' ) ) {
 	add_action( 'admin_notices', '_wpsc_admin_notices_3dot8dot9' );
+
+  if ( isset( $_REQUEST['dismiss_389_upgrade_notice'] ) ) {
+    update_option( 'wpsc_hide_3.8.9_notices', true );
+  }
+}
 
 /**
  * Checks to ensure that shipping is enabled, and one or both of the shipping/billing states are not displayed.
@@ -1622,12 +1624,13 @@ the "billingcountry" and "shippingcountry" settings to control the visibility of
 	echo '<div id="wpsc-3-8-14-1-notice" class="error">' . $message . '</div>';
 }
 
-if ( isset( $_REQUEST['dismiss_3_8_14_1_upgrade_notice'] ) || version_compare( WPSC_VERSION, '3.9', '>=' ) ) {
-	update_option( 'wpsc_hide_3_8_14_1_notices', true );
-}
-
-if ( ! get_option( 'wpsc_hide_3_8_14_1_notices' ) )
+if ( ! get_option( 'wpsc_hide_3_8_14_1_notices' ) ) {
 	add_action( 'admin_notices', '_wpsc_admin_notices_3_8_14_1' );
+
+  if ( isset( $_REQUEST['dismiss_3_8_14_1_upgrade_notice'] ) ) {
+    update_option( 'wpsc_hide_3_8_14_1_notices', true );
+  }
+}
 
 /**
  * @todo docs


### PR DESCRIPTION
The upgrade notice options are only updated when the user dismisses the notice.