### PR TITLE
verify that the count of shipping items is correct before using it 

### DIFF
--- a/wpsc-includes/cart.class.php
+++ b/wpsc-includes/cart.class.php
@@ -1195,7 +1195,9 @@ class wpsc_cart {
 
 		$this->current_shipping_method = - 1;
 
-		if ( $this->shipping_method_count > 0 && ! empty( $this->shipping_methods ) ) {
+		$this->shipping_method_count = count( $this->shipping_methods );
+
+		if ( $this->shipping_method_count > 0 ) {
 			$this->shipping_method = $this->shipping_methods[0];
 		}
 	}


### PR DESCRIPTION
to set a default shipping method or anything else/
it appears that there are circumstances where the value is not initialized prior to use, this seems to clear it up