### PR TITLE
Make sure customer cookie value is url decoded prior to use

### DIFF
--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -87,7 +87,7 @@ function wpsc_element_is_visible( el ) {
             bottom = top + jQuery(window).height(),
             elTop = el.offset().top;
 
-        $visible = ( (elTop >= top ) && ( elTop <= bottom ) && ( elTop <= bottom ) && ( elTop >= top ) ) && el.is(':visible');
+        visible = ( (elTop >= top ) && ( elTop <= bottom ) && ( elTop <= bottom ) && ( elTop >= top ) ) && el.is(':visible');
     } else {
         visible = false;
     }
@@ -143,13 +143,13 @@ function wpsc_var_set( name, value ) {
 // a global variable used to hold the current users visitor id,
 // if you are going to user it always check to be sure it is not false
 var wpsc_visitor_id = false;
-    var i, cookieName, cookieValue, docCookies = document.cookie.split( ";" );
+    var i, cookieName, cookieValue, docCookies = document.cookie.split( ';' );
     for ( i = 0; i < docCookies.length; i++ ) {
-        cookieName  = docCookies[i].substr( 0, docCookies[i].indexOf( "=" ) );
-        cookieName  = cookieName.replace( /^\s+|\s+$/g,"" );
-        cookieValue = docCookies[i].substr( docCookies[i].indexOf("=") + 1) ;
+        cookieName  = docCookies[i].substr( 0, docCookies[i].indexOf( '=' ) );
+        cookieName  = cookieName.replace( /^\s+|\s+$/g, '' );
+        cookieValue = docCookies[i].substr( docCookies[i].indexOf('=') + 1);
             var cookieValueClean = decodeURI(cookieValue);
-            var idAsText = cookieValueClean.substr(0,cookieValueClean.indexOf( "|" ) );
+            var idAsText = cookieValueClean.substr(0,cookieValueClean.indexOf( '|' ) );
 
 if ( document.cookie.indexOf("wpsc_customer_cookie") < 0 ) {
 	if ( document.cookie.indexOf("wpsc_attempted_validate") < 0 ) {

--- a/wpsc-core/wpsc-functions.php
+++ b/wpsc-core/wpsc-functions.php
@@ -215,6 +215,12 @@ function wpsc_javascript_localizations( $localizations = false ) {
 		$localizations['WPSC_CORE_IMAGES_URL']     = WPSC_CORE_IMAGES_URL;
 		$localizations['fileThickboxLoadingImage'] = WPSC_CORE_IMAGES_URL . '/loadingAnimation.gif';
 		$localizations['msg_shipping_need_recalc'] = __( 'Please click the <em>Calculate</em> button to refresh your shipping quotes, as your shipping information has been modified.', 'wpsc' );
+
+		// if we are in debug mode tell the script it is ok to log messages and such
+		if ( wpsc_in_debug_mode()) {
+			$localizations['debug'] = '1';
+		}
+
 	}
 
 	/**
@@ -955,3 +961,51 @@ function _wpsc_clear_wp_cache_on_version_change() {
 }
 
 add_action( 'admin_init', '_wpsc_clear_wp_cache_on_version_change', 1 );
+
+/**
+ * Check if awe are in 'debug' mode, use if you want to conditionally output messages to the error log
+ * or admistrator console
+ *
+ * Debug mode will be enabled if WordPress debug mode is enabled
+ * Debug mode will be set if the constant WPSC_DEBUG is defined and evaluates to true
+ * Debug mode can be set by a logged in administrative user by appending '?wpsc_debug_mode=1' to the end of any site url
+ *
+ * @return bool
+ */
+function wpsc_in_debug_mode() {
+	$wpsc_debug_mode = false;
+
+	// is WordPress debug mode on?
+	if ( defined( 'WP_DEBUG') && WP_DEBUG ) {
+		$wpsc_debug_mode = true;
+	}
+
+	// is WPeC debug mode on?
+	if ( defined( 'WPSC_DEBUG') && WPSC_DEBUG ) {
+		$wpsc_debug_mode = true;
+	}
+
+	// get the value of the debug mode option, if it is not defined create it so that
+	// the option is cached and debug mode can be determined with greate haste
+	$debug_mode_option = intval( get_option( 'wpsc_debug_mode', -1 ) );
+	if( -1 == $debug_mode_option ) {
+		$debug_mode_option = 0;
+		update_option( 'wpsc_debug_mode', $debug_mode_option );
+	}
+
+	// has debug mode been enabled from a url request by an administrator
+	if (  isset( $_REQUEST['wpsc_debug_mode'] ) ) {
+		if ( funtion_exists( 'current_user_can' ) && current_user_can( 'manage_options' ) ) {
+			$debug_mode_option = intval( $_REQUEST['wpsc_debug_mode'] );
+			update_option( 'wpsc_debug_mode', $debug_mode_option );
+		}
+	}
+
+	// has debug mode been previously enabled by an administrator request
+	if ( $debug_mode_option ) {
+		$wpsc_debug_mode = true;
+	}
+
+	return $wpsc_debug_mode;
+
+}

--- a/wpsc-includes/customer-private.php
+++ b/wpsc-includes/customer-private.php
@@ -175,6 +175,10 @@ function _wpsc_create_customer_id_cookie( $id, $fake_it = false ) {
 
 	$cookie = $id . '|' . $expire . '|' . $visitor_hash;
 
+	if ( headers_sent() ) {
+		error_log( 'WPeC Customer Cookie for shopper id ' . $id . '  can not be set because headers have already been sent?' );
+	}
+
 	// store ID, expire and hash to validate later
 	if ( headers_sent() || $fake_it ) {
 		$_COOKIE[ WPSC_CUSTOMER_COOKIE ] = $cookie;
@@ -218,7 +222,7 @@ function _wpsc_validate_customer_cookie() {
 		return false;
 	}
 
-	$cookie = $_COOKIE[ WPSC_CUSTOMER_COOKIE ];
+	$cookie = urldecode( $_COOKIE[ WPSC_CUSTOMER_COOKIE ] );
 
 	list( $id, $expire, $visitor_hash_from_cookie ) = $x = explode( '|', $cookie );
 
@@ -330,7 +334,6 @@ function _wpsc_merge_cart() {
 
 	$id_from_customer_meta = wpsc_get_customer_meta( 'merge_cart_vistor_id' );
 	wpsc_delete_customer_meta( 'merge_cart_vistor_id' );
-
 
 	$old_cart = wpsc_get_customer_cart( $id_from_customer_meta );
 	$items    = $old_cart->get_items();

--- a/wpsc-includes/customer-private.php
+++ b/wpsc-includes/customer-private.php
@@ -175,10 +175,6 @@ function _wpsc_create_customer_id_cookie( $id, $fake_it = false ) {
 
 	$cookie = $id . '|' . $expire . '|' . $visitor_hash;
 
-	if ( headers_sent() ) {
-		error_log( 'WPeC Customer Cookie for shopper id ' . $id . '  can not be set because headers have already been sent?' );
-	}
-
 	// store ID, expire and hash to validate later
 	if ( headers_sent() || $fake_it ) {
 		$_COOKIE[ WPSC_CUSTOMER_COOKIE ] = $cookie;


### PR DESCRIPTION
addresses issue #1786 

Make sure customer cookie value is decoded prior to breaking it into components, in php and js/wp-e-commerce

Much console output is being generated in the WPeC javascript, this output is useful when examining cases, but the rest of the time it is a distraction and makes it more difficult to notice problems, so...

Wrapped output to console in test to see if we are in debug mode
Added debug mode indicator to localized javascript data when debug mode is enabled at the server
Added utility routine to check for debug mode to core

Utility routine that checks for debug mode enabled implemented.

Debug mode determined to be enabled when WordPress debug mode is enabled via constant definition
Debug mode determined to be enabled when WPeC debug mode is enabled via constant definition
Debug mode can be enabled/disabled persistently at runtime by a logged in administrative user putting a parameter onto a store url. This will enable WPeC support to enable debug mode via the internet without having to access source code.

Also: added check to `wpsc_element_is_visible` so it doesn't error when called with an undefined element.  That call happens when non-standard checkout form field configurations are used.
