### PR TITLE
Dont add option tags to hidden inputs

### DIFF
--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -649,7 +649,7 @@ function wpsc_update_regions_list_to_match_country( country_select ) {
 	}
 
 	var region_select      = wpsc_country_region_element( country_select );
-	var all_region_selects = wpsc_get_wpsc_meta_elements( region_meta_key );
+	var all_region_selects = wpsc_get_wpsc_meta_elements( region_meta_key ).filter( 'select' );
 	var country_code       = wpsc_get_value_from_wpsc_meta_element( country_select );
 	var region             = wpsc_get_value_from_wpsc_meta_element( region_meta_key );
 

--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -106,6 +106,22 @@ function wpsc_var_set( name, value ) {
 	return undefined;
 }
 
+/**
+ * Create an <option> tag in a cross-browser manner.
+ * See: https://github.com/wp-e-commerce/WP-e-Commerce/issues/1792
+ *
+ * @since 4.0
+ *
+ * @param {string} displaytext              The text to put between the <option></option> tags.
+ * @param {string|int|float} [value='']     The value's option, (for the "value" attribute).
+ *
+ * @returns {*}         A jQuerified <option> element.
+ */
+function wpsc_create_option(  displaytext, value ) {
+	if ( 'undefined' === value ) value = '';
+	return jQuery( document.createElement( 'option' ) ).val( value ).text( displaytext );
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////
 // Setting up the WPEC customer identifier
 //
@@ -564,11 +580,11 @@ function wpsc_countries_lists_handle_restrictions() {
 
 		country_drop_downs.empty();
 
-		country_drop_downs.append( new Option( wpsc_var_get( 'no_country_selected' ), '' ) );
+		country_drop_downs.append( wpsc_create_option( wpsc_var_get( 'no_country_selected' ) ) );
 		for ( var isocode in wpsc_acceptable_shipping_countries ) {
 			if ( wpsc_acceptable_shipping_countries.hasOwnProperty( isocode ) ) {
 				var country_name = wpsc_acceptable_shipping_countries[isocode];
-				country_drop_downs.append( new Option( country_name, isocode ) );
+				country_drop_downs.append( wpsc_create_option( country_name, isocode ) );
 			}
 		}
 
@@ -579,12 +595,12 @@ function wpsc_countries_lists_handle_restrictions() {
 			country_drop_downs = jQuery( selector );
 			if ( country_drop_downs.length ) {
 				country_drop_downs.empty();
-				country_drop_downs.append( new Option( wpsc_var_get( 'no_country_selected' ), '' ) );
+				country_drop_downs.append( wpsc_create_option( wpsc_var_get( 'no_country_selected' ) ) );
 				countries = wpsc_var_get( 'wpsc_countries' );
 				for ( var isocode in countries ) {
 					if ( countries.hasOwnProperty( isocode ) ) {
 						var country_name = countries[isocode];
-						country_drop_downs.append( new Option( country_name, isocode ) );
+						country_drop_downs.append( wpsc_create_option( country_name, isocode ) );
 				  	}
 				}
 			}
@@ -657,11 +673,11 @@ function wpsc_update_regions_list_to_match_country( country_select ) {
 		var select_a_region_message = wpsc_no_region_selected_message( country_code );
 		var regions = wpsc_country_regions( country_code );
 		all_region_selects.empty();
-		all_region_selects.append( new Option( select_a_region_message, '' ) );
+		all_region_selects.append( wpsc_create_option( select_a_region_message ) );
 		for ( var region_code in regions ) {
 		  if ( regions.hasOwnProperty( region_code ) ) {
 			  var region_name = regions[region_code];
-			  all_region_selects.append( new Option( region_name, region_code ) );
+			  all_region_selects.append( wpsc_create_option( region_name,  region_code ) );
 		  }
 		}
 


### PR DESCRIPTION
This fixes #1791 and #1792.

I added a `wpsc_create_option()` function instead of repeating the slightly messy jQuery code everywhere `new Option()` was used. I'm not sure what we usually do for the `@since` directive, so I made it say since 4.0, although I would like these fixes to go out ASAP, and I don't know if 4.0 will be released soon.