### PR TITLE
Gold cart purchase link

### DIFF
--- a/wpsc-components/theme-engine-v1/classes/settings-tab-presentation.php
+++ b/wpsc-components/theme-engine-v1/classes/settings-tab-presentation.php
@@ -460,7 +460,7 @@ class WPSC_Settings_Tab_Presentation extends WPSC_Settings_Tab {
 					<?php
 						if ( ! function_exists( 'product_display_grid' ) ) {
 					?>
-					<a href='http://wpecommerce.org/store/premium-plugins/'><?php esc_html_e( 'Purchase unavailable options', 'wpsc' ); ?></a>
+					<a href='http://wpecommerce.org/store/premium-plugins/gold-cart/'><?php esc_html_e( 'Purchase unavailable options', 'wpsc' ); ?></a>
 					<?php
 						}
 					?>


### PR DESCRIPTION
Should link directly to the addon and not to the main page, users confused on what needs purchased