### PR TITLE
Bug/null currency

### DIFF
--- a/wpsc-components/theme-engine-v2/helpers/template-tags/common.php
+++ b/wpsc-components/theme-engine-v2/helpers/template-tags/common.php
@@ -60,7 +60,6 @@ function wpsc_format_currency( $amt, $args = '' ) {
 	}
 
 	$currency_code = $currency->get_currency_code();
-
 	// No decimal point, no decimals
 	if ( ! $display_decimal_point || in_array( $currency_code, $currencies_without_fractions ) ) {
 		$decimals = 0;
@@ -78,6 +77,7 @@ function wpsc_format_currency( $amt, $args = '' ) {
 	if ( ! $display_currency_code ) {
 		$currency_code = '';
 	}
+
 
 	$symbol = $display_currency_symbol ? $currency->get_currency_symbol() : '';
 	$symbol = esc_html( $symbol );

--- a/wpsc-components/theme-engine-v2/helpers/template-tags/common.php
+++ b/wpsc-components/theme-engine-v2/helpers/template-tags/common.php
@@ -78,7 +78,6 @@ function wpsc_format_currency( $amt, $args = '' ) {
 		$currency_code = '';
 	}
 
-
 	$symbol = $display_currency_symbol ? $currency->get_currency_symbol() : '';
 	$symbol = esc_html( $symbol );
 	$symbol = apply_filters( 'wpsc_format_currency_currency_symbol', $symbol, $isocode );

--- a/wpsc-components/theme-engine-v2/mvc/controllers/checkout.php
+++ b/wpsc-components/theme-engine-v2/mvc/controllers/checkout.php
@@ -405,7 +405,7 @@ class WPSC_Controller_Checkout extends WPSC_Controller {
 		$decimals            = apply_filters( 'wpsc_modify_decimals'                 , $decimals, $isocode );
 		$decimal_separator   = apply_filters( 'wpsc_format_currency_decimal_separator'  , wpsc_get_option( 'decimal_separator' ), $isocode );
 		$thousands_separator = apply_filters( 'wpsc_format_currency_thousands_separator', wpsc_get_option( 'thousands_separator' ), $isocode );
-		$symbol = apply_filters( 'wpsc_format_currency_currency_symbol', $currency->get( 'symbol' ), $isocode );
+		$symbol = apply_filters( 'wpsc_format_currency_currency_symbol', $currency->get_currency_symbol() );
 		$sign_location = get_option( 'currency_sign_location' );
 
 		$js_var['formatter'] = array(

--- a/wpsc-components/theme-engine-v2/theming/assets/js/shipping-price-simulator.js
+++ b/wpsc-components/theme-engine-v2/theming/assets/js/shipping-price-simulator.js
@@ -13,7 +13,7 @@
 		}
 
 		num = parts.join(WPSC_Price_Table.formatter.decimal_separator);
-		console.log( WPSC_Price_Table );
+
 		switch ( WPSC_Price_Table.formatter.sign_location * 1 ) {
 			case 1:
 				return num + WPSC_Price_Table.formatter.symbol;

--- a/wpsc-components/theme-engine-v2/theming/assets/js/shipping-price-simulator.js
+++ b/wpsc-components/theme-engine-v2/theming/assets/js/shipping-price-simulator.js
@@ -13,7 +13,7 @@
 		}
 
 		num = parts.join(WPSC_Price_Table.formatter.decimal_separator);
-
+		console.log( WPSC_Price_Table );
 		switch ( WPSC_Price_Table.formatter.sign_location * 1 ) {
 			case 1:
 				return num + WPSC_Price_Table.formatter.symbol;


### PR DESCRIPTION
Fixes the issue with the currency symbol being shown as `null` on the `Delivery` page of the checkout process.

Related to #848