### PR TITLE
abstracting getting variation product id from variation selections

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -120,7 +120,7 @@ function wpsc_add_to_cart() {
 	}
 
 	if ( isset( $_POST['variation'] ) ) {
-		$product_id = wpsc_get_product_id_from_variations( $_POST['variation'] );
+		$product_id = wpsc_get_product_id_from_variations( $_POST['variation'], $product_id );
 	}
 
 	if ( (isset( $_POST['quantity'] ) && $_POST['quantity'] > 0) && (!isset( $_POST['wpsc_quantity_update'] )) ) {

--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -85,7 +85,7 @@ function wpsc_special_widget() {
  * add_to_cart function, used through ajax and in normal page loading.
  * No parameters, returns nothing
  *
- * @uses wpsc_get_product_id_from_variation_selections()                Given array of variation selections returns the variation product id as int
+ * @uses wpsc_get_product_id_from_variations()              Given array of variation selections returns the variation product id as int
  */
 function wpsc_add_to_cart() {
 	global $wpsc_cart;
@@ -120,7 +120,7 @@ function wpsc_add_to_cart() {
 	}
 
 	if ( isset( $_POST['variation'] ) ) {
-		$product_id = wpsc_get_product_id_from_variation_selections( $_POST['variation'] );
+		$product_id = wpsc_get_product_id_from_variations( $_POST['variation'] );
 	}
 
 	if ( (isset( $_POST['quantity'] ) && $_POST['quantity'] > 0) && (!isset( $_POST['wpsc_quantity_update'] )) ) {

--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -120,7 +120,9 @@ function wpsc_add_to_cart() {
 	}
 
 	if ( isset( $_POST['variation'] ) ) {
-		$product_id = wpsc_get_product_id_from_variations( $_POST['variation'], $product_id );
+		$return_variation_params                 = wpsc_get_product_id_from_variations( $_POST['variation'], $product_id );
+		$product_id                              = $return_variation_params['product_id'];
+		$provided_parameters['variation_values'] = $return_variation_params['variation_values'];
 	}
 
 	if ( (isset( $_POST['quantity'] ) && $_POST['quantity'] > 0) && (!isset( $_POST['wpsc_quantity_update'] )) ) {

--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -84,6 +84,8 @@ function wpsc_special_widget() {
 /**
  * add_to_cart function, used through ajax and in normal page loading.
  * No parameters, returns nothing
+ *
+ * @uses wpsc_get_product_id_from_variation_selections()                Given array of variation selections returns the variation product id as int
  */
 function wpsc_add_to_cart() {
 	global $wpsc_cart;
@@ -118,17 +120,7 @@ function wpsc_add_to_cart() {
 	}
 
 	if ( isset( $_POST['variation'] ) ) {
-
-		foreach ( (array) $_POST['variation'] as $key => $variation ) {
-			$provided_parameters['variation_values'][ (int) $key ] = (int) $variation;
-		}
-
-		if ( count( $provided_parameters['variation_values'] ) > 0 ) {
-			$variation_product_id = wpsc_get_child_object_in_terms( $product_id, $provided_parameters['variation_values'], 'wpsc-variation' );
-			if ( $variation_product_id > 0 ) {
-				$product_id = $variation_product_id;
-			}
-		}
+		$product_id = wpsc_get_product_id_from_variation_selections( $_POST['variation'] );
 	}
 
 	if ( (isset( $_POST['quantity'] ) && $_POST['quantity'] > 0) && (!isset( $_POST['wpsc_quantity_update'] )) ) {

--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -120,7 +120,7 @@ function wpsc_add_to_cart() {
 	}
 
 	if ( isset( $_POST['variation'] ) ) {
-		$return_variation_params                 = wpsc_get_product_id_from_variations( $_POST['variation'], $product_id );
+		$return_variation_params                 = wpsc_get_product_data_from_variations( $_POST['variation'], $product_id );
 		$product_id                              = $return_variation_params['product_id'];
 		$provided_parameters['variation_values'] = $return_variation_params['variation_values'];
 	}

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -311,7 +311,7 @@ function wpsc_get_product_id_from_variations( $variations, $product_id ) {
 
 	$provided_parameters = array();
 
-	foreach ( (array) $variations['variation'] as $key => $variation ) {
+	foreach ( (array) $variations as $key => $variation ) {
 		$provided_parameters['variation_values'][ (int) $key ] = (int) $variation;
 	}
 

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -403,8 +403,12 @@ function wpsc_get_variation_values_from_variations( $variations, $product_id ){
 	 *
 	 * @param array $variations             The variation selections passed to the core function
 	 * @param int   $product_id             The default passed product_id
+	 * @param array $values{
+	 *      @param  int     product_id         The variation product_id
+	 *      @param  array   variation_values   The array of variation term_ids based on the selections sent through
+	 * }
 	 */
-	$variation_values = apply_filters( 'wpsc_variation_values', $values['variation_values'], $product_id );
+	$variation_values = apply_filters( 'wpsc_variation_values', $values['variation_values'], $product_id, $values );
 
 	return (array) $variation_values;
 

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -321,6 +321,14 @@ function wpsc_get_product_id_from_variations( $variations ) {
 		}
 	}
 
+	/**
+	 * Allows users to filter the product_id based on the variation selections
+	 *
+	 * @since 4.0
+	 *
+	 * @param int   $product_id             The default passed product_id
+	 * @param array $variations             The variation selections passed to the core function
+	 */
 	return apply_filters( 'wpsc_variation_product_id', absint( $product_id ), $variations );
 
 }

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -318,8 +318,8 @@ function wpsc_get_product_id_from_variations( $variations, $product_id ) {
 		$variation_values[ (int) $key ] = (int) $variation;
 	}
 
-	if ( count( $provided_parameters['variation_values'] ) > 0 ) {
-		$variation_product_id = wpsc_get_child_object_in_terms( $product_id, $provided_parameters['variation_values'], 'wpsc-variation' );
+	if ( count( $variation_values ) > 0 ) {
+		$variation_product_id = wpsc_get_child_object_in_terms( $product_id, $variation_values, 'wpsc-variation' );
 		if ( $variation_product_id > 0 ) {
 			$product_id = $variation_product_id;
 		}

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -368,10 +368,15 @@ function wpsc_get_product_id_from_variations( $variations, $product_id ){
 	 *
 	 * @since 4.0
 	 *
-	 * @param int   $product_id             The default passed product_id
+	 * @param int   $$values['product_id']  The variation product_id
 	 * @param array $variations             The variation selections passed to the core function
+	 * @param int   $product_id             The originally passed $product_id
+	 * @param array $values{
+	 *      @param  int     product_id         The variation product_id
+	 *      @param  array   variation_values   The array of variation term_ids based on the selections sent through
+	 * }
 	 */
-	$product_id = apply_filters( 'wpsc_variation_product_id', absint( $values['product_id'] ), $variations );
+	$product_id = apply_filters( 'wpsc_variation_product_id', absint( $values['product_id'] ), $variations, $product_id, $values );
 
 	return absint( $product_id );
 

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -354,3 +354,59 @@ function wpsc_get_product_data_from_variations( $variations, $product_id ) {
 	return $return_args;
 
 }
+
+/**
+ * Wrapper for wpsc_get_product_data_from_variations that returns the variation product_id
+ *
+ * See wpsc_get_product_data_from_variations for a full description on what needs to be passed in the $variations params
+ *
+ * @since 4.0
+ *
+ * @uses wpsc_get_product_data_from_variations()                        Returns array of data pertaining to product variations
+ * @return int      $product_id                                         The product_id corresponding to the selected variation
+ */
+function wpsc_get_product_id_from_variations( $variations, $product_id ){
+
+	$values = wpsc_get_product_data_from_variations( $variations, $product_id );
+
+	/**
+	 * Allows users to filter the product_id based on the variation selections
+	 *
+	 * @since 4.0
+	 *
+	 * @param int   $product_id             The default passed product_id
+	 * @param array $variations             The variation selections passed to the core function
+	 */
+	$product_id = apply_filters( 'wpsc_variation_product_id', absint( $values['product_id'] ), $variations );
+
+	return absint( $product_id );
+
+}
+
+/**
+ * Wrapper for wpsc_get_product_data_from_variations that returns the variation values corresponding to the variation selections
+ *
+ * See wpsc_get_product_data_from_variations for a full description on what needs to be passed in the $variations params
+ *
+ * @since 4.0
+ *
+ * @uses wpsc_get_product_data_from_variations()                        Returns array of data pertaining to product variations
+ * @return array      $variation_values                                 The variation values for the selected variation terms, so the term_ids as the array $values
+ */
+function wpsc_get_variation_values_from_variations( $variations, $product_id ){
+
+	$values = wpsc_get_product_data_from_variations( $variations, $product_id );
+
+	/**
+	 * Allows users to filter the variation values based on the variation selections
+	 *
+	 * @since 4.0
+	 *
+	 * @param array $variations             The variation selections passed to the core function
+	 * @param int   $product_id             The default passed product_id
+	 */
+	$variation_values = apply_filters( 'wpsc_variation_values', $values['variation_values'], $product_id );
+
+	return (array) $variation_values;
+
+}

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -309,10 +309,10 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
  */
 function wpsc_get_product_id_from_variations( $variations, $product_id ) {
 
-	$provided_parameters = array();
+	$variation_values = array();
 
 	foreach ( (array) $variations as $key => $variation ) {
-		$provided_parameters['variation_values'][ (int) $key ] = (int) $variation;
+		$variation_values[ (int) $key ] = (int) $variation;
 	}
 
 	if ( count( $provided_parameters['variation_values'] ) > 0 ) {
@@ -330,6 +330,13 @@ function wpsc_get_product_id_from_variations( $variations, $product_id ) {
 	 * @param int   $product_id             The default passed product_id
 	 * @param array $variations             The variation selections passed to the core function
 	 */
-	return apply_filters( 'wpsc_variation_product_id', absint( $product_id ), $variations );
+	$product_id = apply_filters( 'wpsc_variation_product_id', absint( $product_id ), $variations );
+
+	$return_args = array(
+		'product_id'       => $product_id,
+		'variation_values' => $variation_values,
+	);
+
+	return $return_args;
 
 }

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -296,3 +296,30 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
 		return false;
 	}
 }
+
+/**
+ * Given array of variation selections this works through the terms and returns the product_id for the matching variation
+ *
+ * @since 4.0
+ * @author Curtis McHale
+ *
+ * @param array     $variations     required            The array of variation selections
+ * @uses wpsc_get_child_objects_in_terms()              Given $product_id and product params this returns the variation product id
+ * @return int      $product_id                         The ID of the variation product
+ */
+function wpsc_get_product_id_from_variation_selections( $variations ){
+
+	foreach ( (array) $variations['variation'] as $key => $variation ) {
+		$provided_parameters['variation_values'][ (int) $key ] = (int) $variation;
+	}
+
+	if ( count( $provided_parameters['variation_values'] ) > 0 ) {
+		$variation_product_id = wpsc_get_child_object_in_terms( $product_id, $provided_parameters['variation_values'], 'wpsc-variation' );
+		if ( $variation_product_id > 0 ) {
+			$product_id = $variation_product_id;
+		}
+	}
+
+	return absint( $product_id );
+
+}

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -321,6 +321,6 @@ function wpsc_get_product_id_from_variations( $variations ) {
 		}
 	}
 
-	return absint( $product_id );
+	return apply_filters( 'wpsc_variation_product_id', absint( $product_id ), $variations );
 
 }

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -301,7 +301,6 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
  * Given array of variation selections this works through the terms and returns the product_id for the matching variation
  *
  * @since 4.0
- * @author Curtis McHale
  *
  * @param array     $variations     required            The array of variation selections
  * @uses wpsc_get_child_objects_in_terms()              Given $product_id and product params this returns the variation product id

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -310,7 +310,7 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
  *      @param  array   variation_values                The array of variation_values that wpsc_add_to_cart needs to populate $provided_parameters['variation_values']
  * }
  */
-function wpsc_get_product_id_from_variations( $variations, $product_id ) {
+function wpsc_get_product_data_from_variations( $variations, $product_id ) {
 
 	$variation_values = array();
 

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -300,6 +300,17 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
 /**
  * Given array of variation selections this works through the terms and returns the product_id for the matching variation
  *
+ * For the `$variations` parameter we expect to get two 'term_ids' which correspond to the selections in the variation.
+ * So if we have a blue large shirt and the blue term_id is 8 and the large term_id is 12 we would get an array that looks like.
+ *
+ * array(
+ *      '2' => '8',     // this is the blue term_id
+ *      '9' => '12',    // this is the large term_id
+ * );
+ *
+ * Here the keys are captured when someone clicks the 'add to cart' button and correspond with ... whatever. They don't really matter for our function.
+ * Really ou could pass an array of 2 term_ids here and a $product_id that has variations to match those terms and you'd get back the expected array.
+ *
  * @since 4.0
  *
  * @param array     $variations     required            The array of variation selections

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -307,7 +307,9 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
  * @uses wpsc_get_child_objects_in_terms()              Given $product_id and product params this returns the variation product id
  * @return int      $product_id                         The ID of the variation product
  */
-function wpsc_get_product_id_from_variation_selections( $variations ){
+function wpsc_get_product_id_from_variations( $variations ) {
+
+	$provided_parameters = array();
 
 	foreach ( (array) $variations['variation'] as $key => $variation ) {
 		$provided_parameters['variation_values'][ (int) $key ] = (int) $variation;

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -305,7 +305,10 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
  * @param array     $variations     required            The array of variation selections
  * @param int       $product_id     required            The default product_id
  * @uses wpsc_get_child_objects_in_terms()              Given $product_id and product params this returns the variation product id
- * @return int      $product_id                         The ID of the variation product
+ * @return array    $args {
+ *      @param  int     product_id                      The variation product_id
+ *      @param  array   variation_values                The array of variation_values that wpsc_add_to_cart needs to populate $provided_parameters['variation_values']
+ * }
  */
 function wpsc_get_product_id_from_variations( $variations, $product_id ) {
 

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -302,6 +302,8 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
  *
  * For the `$variations` parameter we expect to get two 'term_ids' which correspond to the selections in the variation.
  * So if we have a blue large shirt and the blue term_id is 8 and the large term_id is 12 we would get an array that looks like.
+ * They keys in the array ( 2 and 9 below ) don't actually matter and are a result of the array items on the frontend in a typical
+ * 'add to cart' action from the frontend of a theme.
  *
  * array(
  *      '2' => '8',     // this is the blue term_id

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -309,7 +309,7 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
  * );
  *
  * Here the keys are captured when someone clicks the 'add to cart' button and correspond with ... whatever. They don't really matter for our function.
- * Really ou could pass an array of 2 term_ids here and a $product_id that has variations to match those terms and you'd get back the expected array.
+ * Really you could pass an array of 2 term_ids here and a $product_id that has variations to match those terms and you'd get back the expected array.
  *
  * @since 4.0
  *

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -303,10 +303,11 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
  * @since 4.0
  *
  * @param array     $variations     required            The array of variation selections
+ * @param int       $product_id     required            The default product_id
  * @uses wpsc_get_child_objects_in_terms()              Given $product_id and product params this returns the variation product id
  * @return int      $product_id                         The ID of the variation product
  */
-function wpsc_get_product_id_from_variations( $variations ) {
+function wpsc_get_product_id_from_variations( $variations, $product_id ) {
 
 	$provided_parameters = array();
 

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -324,6 +324,7 @@ function wpsc_get_child_object_in_terms_var( $parent_id, $terms, $taxonomies, $a
 function wpsc_get_product_data_from_variations( $variations, $product_id ) {
 
 	$variation_values = array();
+	$original_product_id = $product_id;
 
 	foreach ( (array) $variations as $key => $variation ) {
 		$variation_values[ (int) $key ] = (int) $variation;
@@ -336,15 +337,8 @@ function wpsc_get_product_data_from_variations( $variations, $product_id ) {
 		}
 	}
 
-	/**
-	 * Allows users to filter the product_id based on the variation selections
-	 *
-	 * @since 4.0
-	 *
-	 * @param int   $product_id             The default passed product_id
-	 * @param array $variations             The variation selections passed to the core function
-	 */
-	$product_id = apply_filters( 'wpsc_variation_product_id', absint( $product_id ), $variations );
+	/** This filter is documented in wpsc_get_product_id_from_variations */
+	$product_id = apply_filters( 'wpsc_variation_product_id', absint( $product_id ), $variations, absint( $original_product_id ) );
 
 	$return_args = array(
 		'product_id'       => absint( $product_id ),

--- a/wpsc-includes/variations.class.php
+++ b/wpsc-includes/variations.class.php
@@ -336,7 +336,7 @@ function wpsc_get_product_id_from_variations( $variations, $product_id ) {
 	$product_id = apply_filters( 'wpsc_variation_product_id', absint( $product_id ), $variations );
 
 	$return_args = array(
-		'product_id'       => $product_id,
+		'product_id'       => absint( $product_id ),
 		'variation_values' => $variation_values,
 	);
 


### PR DESCRIPTION
Here we pull out the loops in wpsc_add_to_cart that took the variation
selection and parsed it down to a variation_product_id and moved them in
to their own function.

This allows developers to leverage a core WPSC function instead of
maintaining their own loops to get the variation_product_id and then
needing to maintain them long term.

It also breaks out the huge function that is wpsc_add_to_cart in to one
more smaller part that we could write a unit test for without it being
buried deep down inside another function.

See #1813 for initial issue submission.

- this is tagged as @since 4.0 so that shoud be verified before we merge this