### PR TITLE
An attempt at stopping the intermittent initiialization deserialization error of the country map

### DIFF
--- a/wpsc-core/wpsc-includes.php
+++ b/wpsc-core/wpsc-includes.php
@@ -36,11 +36,11 @@ require_once( WPSC_FILE_PATH . '/wpsc-includes/stats.functions.php'             
 require_once( WPSC_FILE_PATH . '/wpsc-includes/meta.functions.php'                  );
 require_once( WPSC_FILE_PATH . '/wpsc-includes/productfeed.php'                     );
 require_once( WPSC_FILE_PATH . '/wpsc-includes/image_processing.php'                );
+require_once( WPSC_FILE_PATH . '/wpsc-includes/wpsc-data-map.class.php'             );
 require_once( WPSC_FILE_PATH . '/wpsc-includes/wpsc-country.class.php'              );
 require_once( WPSC_FILE_PATH . '/wpsc-includes/wpsc-countries.class.php'            );
 require_once( WPSC_FILE_PATH . '/wpsc-includes/wpsc-region.class.php'               );
 require_once( WPSC_FILE_PATH . '/wpsc-includes/wpsc-currency.class.php'             );
-require_once( WPSC_FILE_PATH . '/wpsc-includes/wpsc-data-map.class.php'             );
 require_once( WPSC_FILE_PATH . '/wpsc-includes/country-region-tax-util.php'         );
 require_once( WPSC_FILE_PATH . '/wpsc-includes/currency.helpers.php'                );
 require_once( WPSC_FILE_PATH . '/wpsc-includes/purchase-log.helpers.php'            );


### PR DESCRIPTION
move include of datamap class before country class in an attempt to avoid errors such as this:

Fatal error: WPSC_Countries::_dirty(): The script tried to execute a method or access a property of an incomplete object. Please ensure that the class definition "WPSC_Data_Map" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide a __autoload() function to load the class definition in wp-e-commerce/wpsc-includes/wpsc-countries.class.php on line 1142"