### PR TITLE
fix check for callable shipping status function

### DIFF
--- a/wpsc-includes/purchaselogs.class.php
+++ b/wpsc-includes/purchaselogs.class.php
@@ -63,7 +63,10 @@ function wpsc_purchlogitem_trackid() {
 function wpsc_purchlogitem_trackstatus() {
 	global $wpsc_shipping_modules, $purchlogitem;
 
-	if ( is_callable( $wpsc_shipping_modules [$purchlogitem->extrainfo->shipping_method]->getStatus ) && ! empty( $purchlogitem->extrainfo->track_id ) ) {
+	$callable = array( $purchlogitem->extrainfo->shipping_method, 'getStatus' );
+	$shipping_status_is_callable = is_callable( $callable );
+
+	if ( $shipping_status_is_callable && ! empty( $purchlogitem->extrainfo->track_id ) ) {
 		$status = $wpsc_shipping_modules [$purchlogitem->extrainfo->shipping_method]->getStatus( $purchlogitem->extrainfo->track_id );
 	} else {
 		$status = '';


### PR DESCRIPTION
Eliminates php errors like the one below on purchase log detail pages

PHP Notice:  Undefined property: Pbci_Stamps_Com_Shipping::$getStatus in D:\web-site-dev\sparkle-gear.com\wp-content\mu-plugins\WP-e-Commerce\wpsc-includes\purchaselogs.class.php on line 66

Fixes #1838

