### PR TITLE
Bug fixes for the PayPal Gateways

### DIFF
--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -225,7 +225,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 	 * @since 3.9
 	 */
 	public function get_mark_html() {
-		$html = '<a href="https://www.paypal.com/webapps/mpp/paypal-popup" title="' . esc_attr__( 'How PayPal Works' ) . '" onclick="javascript:window.open(\'https://www.paypal.com/webapps/mpp/paypal-popup\',\'WIPaypal\',\'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700\'); return false;"><img src="https://www.paypalobjects.com/webstatic/mktg/logo/pp_cc_mark_37x23.jpg" border="0" alt="PayPal Logo"></a>';
+		$html = '<img src="https://www.paypalobjects.com/webstatic/mktg/logo/pp_cc_mark_37x23.jpg" border="0" alt="PayPal Logo">';
 
 		return apply_filters( 'wpsc_paypal-ec_mark_html', $html );
 	}

--- a/wpsc-components/merchant-core-v3/gateways/paypal-pro.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-pro.php
@@ -80,8 +80,13 @@ class WPSC_Payment_Gateway_Paypal_Pro extends WPSC_Payment_Gateway {
 	 */
 	public static function pro_script() {
 		if ( wpsc_is_checkout() ) {
+			$pro_loc = array(
+				'spinner_url' => wpsc_get_ajax_spinner(),
+				'loading'     => __( 'Loading...', 'wpsc' ),
+			);
 			wp_enqueue_script( 'pro-script-internal', WPSC_URL . '/wpsc-components/merchant-core-v3/gateways/pro.js', array( 'jquery' ) );
 			wp_enqueue_style( 'pro-syle-internal', WPSC_URL . '/wpsc-components/merchant-core-v3/gateways/pro.css' );
+			wp_localize_script( 'pro-script-internal', 'pro_loc', $pro_loc );
 		}
 	}
 

--- a/wpsc-components/merchant-core-v3/gateways/pro.css
+++ b/wpsc-components/merchant-core-v3/gateways/pro.css
@@ -1,6 +1,7 @@
 /* Desktop CSS */
 IFRAME[name=hss_iframe] {
 	max-width: none;
+	display: none;
 }
 FORM[target=hss_iframe] {
 	display: none;

--- a/wpsc-components/merchant-core-v3/gateways/pro.js
+++ b/wpsc-components/merchant-core-v3/gateways/pro.js
@@ -22,10 +22,14 @@
 				} );
 
 				// Insert iFrame
-				$container.html( '<iframe name="hss_iframe" width="570px" height="540px"></iframe>' );
+				$container.html( '<iframe id="pro-iframe" name="hss_iframe" width="570px" height="540px"></iframe>' );
+
+				// Insert the Spinner
+				$container.after( '<img src="' + pro_loc.spinner_url + '" class="pro-spinner" alt="spinner" />' );
+				var $spinner = $( '.pro-spinner' );
 
 				// Call the PayPal Pro API
-				$.ajax({
+				$.ajax( {
 					type: "POST",
 					url: window.location,
 					data: $form.serialize() + '&custom_gateway=paypal-pro',
@@ -36,9 +40,14 @@
 						$hss_form = $( 'FORM', $container );
 						$hss_form.attr( 'target', 'hss_iframe' );
 						$hss_form.find( 'input[type="image"]' ).click();
-					}
 
-				});
+						// Remove the Spinner
+						$spinner.hide();
+
+						// Show the IFRAME
+						$( '#pro-iframe' ).show();
+					}
+				} );
 			}
 		} );
 	} );


### PR DESCRIPTION
This fixes

- Remove Expresscheckout and Digital goods icon popups

- Add a Spinner for PayPal Pro Hosted
Issue: Once i click Purchase on checkout the gateways list is hidden and so is the button so the page looks like a big white space until the paypal "response" comes back with the card input data..maybe a spinner or something so the user knows to hold on until it loads ?

https://dl.dropboxusercontent.com/u/16683640/Screenshots/2015-04-30_2307.png