### PR TITLE
Add full TE2 templating to ajax

### DIFF
--- a/wpsc-components/theme-engine-v2/core.php
+++ b/wpsc-components/theme-engine-v2/core.php
@@ -45,7 +45,7 @@ function _wpsc_te_v2_includes() {
 		require_once( WPSC_THEME_ENGINE_V2_PATH . '/admin.php' );
 	}
 
-	if ( ! is_admin() ) {
+	if ( ! is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX )  ) {
 		_wpsc_te2_mvc_init();
 	}
 


### PR DESCRIPTION
This gives us full TE2 template tags in our AJAX requests so we can do stuff like `wpsc_get_product_title()` which is a pretty common scenario in AJAX requests.