### PR TITLE
flipping the condition to include for ajax

### DIFF
--- a/wpsc-components/theme-engine-v2/core.php
+++ b/wpsc-components/theme-engine-v2/core.php
@@ -45,7 +45,7 @@ function _wpsc_te_v2_includes() {
 		require_once( WPSC_THEME_ENGINE_V2_PATH . '/admin.php' );
 	}
 
-	if ( ! is_admin() && ! ( defined( 'DOING_AJAX' ) && DOING_AJAX )  ) {
+	if ( ! is_admin() && ( defined( 'DOING_AJAX' ) && DOING_AJAX )  ) {
 		_wpsc_te2_mvc_init();
 	}
 


### PR DESCRIPTION
Before it was set to && which means it had to have both conditions
correct to make it work.

Now we've got || which means if we're NOT in the WordPress admin OR
if we're DOING_AJAX we setup the MVC.

Not sure why my original testing went well, maybe I was just being
hasty.