### PR TITLE
Delete download status entry upon file deletion.

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -1337,6 +1337,10 @@ function _wpsc_delete_file( $product_id, $file_name ) {
 
 	$sql = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_parent = %d AND post_type ='wpsc-product-file'", $file_name, $product_id );
 	$product_id_to_delete = $wpdb->get_var( $sql );
+
+	//Delete wpsc_download_status entry for this file
+	$wpdb->query( $wpdb->prepare( "DELETE FROM `".WPSC_TABLE_DOWNLOAD_STATUS."` WHERE `fileid`=%d AND `product_id` = %d", $product_id_to_delete, $product_id ) );
+
 	return wp_delete_post( $product_id_to_delete, true );
 }
 


### PR DESCRIPTION
When a file linked to a product is deleted the WPSC_TABLE_DOWNLOAD_STATUS entries (all for that file) should be removed since when entering a new or the same file again the post ID will be different thus the fileid will be different and old entries will be just leftovers once a file is deleted.