### PR TITLE
It is possible to have multiple products with the same slug and different statuses (trash, publish, inherit)

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/page.php
+++ b/wpsc-components/theme-engine-v1/helpers/page.php
@@ -567,7 +567,24 @@ function wpsc_single_template( $content ) {
 
 		$is_preview = isset( $wp_query->query_vars['preview'] ) && $wp_query->query_vars['preview'];
 
-		$wpsc_temp_query = new WP_Query( array( 'p' => $wp_query->post->ID , 'post_type' => 'wpsc-product','posts_per_page' => 1, 'preview' => $is_preview ) );
+		/**
+		 * Filter post_status on product query.
+		 *
+		 * Assumes publish, if user has edit_posts capability, can override
+		 *
+		 * @since 4.1.0
+		 *
+		 * @param array array() Allowed post_status values.
+		 */
+		$permitted_post_statuses = current_user_can( $post_type_object->cap->edit_posts ) ? apply_filters( 'wpsc_product_display_status', array( 'publish' ) ) : array( 'publish' );
+
+		$wpsc_temp_query = new WP_Query(
+			array( 'p' => $wp_query->post->ID ,
+			'post_type' => 'wpsc-product',
+			'posts_per_page' => 1,
+			'preview' => $is_preview,
+			'post_status' => $permitted_post_statuses,
+		) );
 
 		list( $wp_query, $wpsc_temp_query ) = array( $wpsc_temp_query, $wp_query ); // swap the wpsc_query object
 		$_wpsc_is_in_custom_loop = true;


### PR DESCRIPTION
It wasn't clear when generating the output of the single product page (wpsc_single_template) in TE1 that the right product would be output. See issue #844 . This adds a filtered parameter for post_status to the query for the wpsc-product being displayed.