### PR TITLE
Yoast GA plugin recently switched to their own javascript object

### DIFF
--- a/wpsc-includes/google-analytics.class.php
+++ b/wpsc-includes/google-analytics.class.php
@@ -184,6 +184,9 @@ class WPSC_Google_Analytics {
 
 		if ( $this->use_universal_analytics() ) {
 
+			// Yoast GA Plugin switched to it's own object name __gaTracker - assign it to our ga object if it exists
+			$output .= "var ga = typeof ga === 'undefined' && typeof __gaTracker !== 'undefined' ? __gaTracker : ga;";
+
 			$output .= "ga('require', 'ecommerce');\n\r";
 
 			$output .= "ga('ecommerce:addTransaction', {


### PR DESCRIPTION
As noted in issue #1736, Yoast Google Analytics diverges from the sample code provided by Google to define their own javascript object (__gaTracker). To compensate, if in wpec settings (Marketing) the site indicates that the site using GA Universal, we will test to see which is defined ga or __gaTracker. If ga is undefined and __gaTracker is defined, then we assign the __gaTracker javascript to ga. So that we then correctly pass ecommerce tracking to Google Analytics (using the function setup by Yoast Google Analytics).