### PR TITLE
Issue #1892 fix

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -731,6 +731,13 @@ function wpsc_submit_checkout( $collected_data = true ) {
 		$purchase_log->save();
 		$purchase_log_id = $purchase_log->get( 'id' );
 
+		//Check to ensure log row was inserted successfully
+		if(is_null($purchase_log_id)) {
+			$error_messages[] = __( 'A database error occured while processing your request.', 'wpsc' );
+			wpsc_update_customer_meta( 'checkout_misc_error_messages', $error_messages );
+			return;
+		}
+
 		if ( $collected_data ) {
 			$wpsc_checkout->save_forms_to_db( $purchase_log_id );
 		}

--- a/wpsc-components/theme-engine-v2/mvc/controllers/checkout.php
+++ b/wpsc-components/theme-engine-v2/mvc/controllers/checkout.php
@@ -313,6 +313,15 @@ class WPSC_Controller_Checkout extends WPSC_Controller {
 
 		$purchase_log->save();
 
+		//Check to ensure purchase log row was inserted successfully
+		if(is_null($purchase_log->get( 'id' ))) {
+			$this->message_collection->add(
+				__( 'A database error occured while processing your request.', 'wpsc' ),
+				'error'
+			);
+			return;
+		}
+
 		$wpsc_cart->log_id = $purchase_log->get( 'id' );
 
 		wpsc_update_customer_meta( 'current_purchase_log_id', $purchase_log->get( 'id' ) );


### PR DESCRIPTION
Added check for successful purchase_log insert for Theme Engine 1 and 2. If an error occurs, the user will be notified to prevent going further in the checkout without a valid purchase log.