### PR TITLE
Pre-fetching countries meta to aid caching and reduce requests.

### DIFF
--- a/wpsc-includes/meta.functions.php
+++ b/wpsc-includes/meta.functions.php
@@ -9,9 +9,17 @@ function wpsc_sanitize_meta_key( $key ) {
 }
 
 /**
- * Gets meta data from the database
- * This needs caching implemented for it, but I have not yet figured out how to make this work for it
+ * Get meta data from the database
+ *
+ * Gets and caches an object's meta using the WordPress Object Cache API
+ * and returns meta for a specific key.
+ *
  * @internal
+ *
+ * @param   integer  $object_id    Object ID.
+ * @param   string   $meta_key     Meta key.
+ * @param   string   $object_type  Object type.
+ * @return  mixed                  Meta value.
  */
 function wpsc_get_meta( $object_id = 0, $meta_key, $object_type ) {
 

--- a/wpsc-includes/meta.functions.php
+++ b/wpsc-includes/meta.functions.php
@@ -19,20 +19,21 @@ function wpsc_get_meta( $object_id = 0, $meta_key, $object_type ) {
 
 	$cache_object_id = $object_id = (int)$object_id;
 	$meta_key = wpsc_sanitize_meta_key( $meta_key );
+
 	$meta_tuple = compact( 'object_type', 'object_id', 'meta_key' );
 	$meta_tuple = apply_filters( 'wpsc_get_meta', $meta_tuple );
-	extract( $meta_tuple, EXTR_OVERWRITE );
 
-	$meta_value = wp_cache_get( $cache_object_id, $object_type );
+	// Get cached meta
+	$meta_value = wp_cache_get( $cache_object_id, $meta_tuple['object_type'] );
 
 	// If not cached, get and cache all object meta
 	if ( $meta_value === false ) {
-		$meta_value = $wpdb->get_results( $wpdb->prepare( "SELECT `meta_key`, `meta_value` FROM `" . WPSC_TABLE_META . "` WHERE `object_type` = %s AND `object_id` = %d", $object_type, $object_id ), OBJECT_K );
-		wp_cache_set( $cache_object_id, $meta_value, $object_type );
+		$meta_value = $wpdb->get_results( $wpdb->prepare( "SELECT `meta_key`, `meta_value` FROM `" . WPSC_TABLE_META . "` WHERE `object_type` = %s AND `object_id` = %d", $meta_tuple['object_type'], $meta_tuple['object_id'] ), OBJECT_K );
+		wp_cache_set( $cache_object_id, $meta_value, $meta_tuple['object_type'] );
 	}
 
-	if ( isset( $meta_value[ $meta_key ] ) ) {
-		return maybe_unserialize( $meta_value[ $meta_key ]->meta_value );
+	if ( isset( $meta_value[ $meta_tuple['meta_key'] ] ) ) {
+		return maybe_unserialize( $meta_value[ $meta_tuple['meta_key'] ]->meta_value );
 	}
 
 	return '';

--- a/wpsc-includes/meta.functions.php
+++ b/wpsc-includes/meta.functions.php
@@ -13,20 +13,19 @@ function wpsc_sanitize_meta_key( $key ) {
  * This needs caching implemented for it, but I have not yet figured out how to make this work for it
  * @internal
  */
-function wpsc_get_meta( $object_id = 0, $meta_key, $type ) {
+function wpsc_get_meta( $object_id = 0, $meta_key, $object_type ) {
 
 	global $wpdb;
 
 	$cache_object_id = $object_id = (int)$object_id;
-	$object_type = $type;
 	$meta_key = wpsc_sanitize_meta_key( $meta_key );
-	$meta_tuple = compact( 'object_type', 'object_id', 'meta_key', 'meta_value', 'type' );
+	$meta_tuple = compact( 'object_type', 'object_id', 'meta_key' );
 	$meta_tuple = apply_filters( 'wpsc_get_meta', $meta_tuple );
 	extract( $meta_tuple, EXTR_OVERWRITE );
 
 	$meta_value = wp_cache_get( $cache_object_id, $object_type );
 
-	// If not cached, get and cache 
+	// If not cached, get and cache all object meta
 	if ( $meta_value === false ) {
 		$meta_value = $wpdb->get_results( $wpdb->prepare( "SELECT `meta_key`, `meta_value` FROM `" . WPSC_TABLE_META . "` WHERE `object_type` = %s AND `object_id` = %d", $object_type, $object_id ), OBJECT_K );
 		wp_cache_set( $cache_object_id, $meta_value, $object_type );

--- a/wpsc-includes/wpsc-countries.class.php
+++ b/wpsc-includes/wpsc-countries.class.php
@@ -898,6 +898,7 @@ class WPSC_Countries {
 		if ( ! is_a( self::$active_wpsc_country_by_country_id, 'WPSC_Data_Map' ) ) {
 			self::_clean_data_maps();
 			self::restore();
+			self::get_countries_meta();
 		}
 
 		// respect the notification that temporary data has been flushed, clear our own cache and ite will rebuild the
@@ -907,6 +908,26 @@ class WPSC_Countries {
 		// save our class data when processing is done
 		add_action( 'shutdown', array( __CLASS__, 'save' ) );
 		self::$_initialized = true;
+	}
+
+	/**
+	 * Get Countries Meta
+	 *
+	 * Returns and caches meta data for all countries to eliminate
+	 * multiple database request for each meta value later.
+	 *
+	 * @return  array  Countries meta
+	 */
+	public static function get_countries_meta() {
+
+		$ids = array();
+
+		foreach ( self::$active_wpsc_country_by_country_id->data() as $c ) {
+			$ids[] = $c->get_id();
+		}
+
+		return wpsc_update_meta_cache( 'WPSC_Country', $ids );
+
 	}
 
 	/**


### PR DESCRIPTION
This resolves issue #1894 by request Country meta in bulk when countries are initialised to prevent the 250 extra DB requests generated when getting meta for individual countries.

Note: Builds on PR #1912 when could be committed first if this needs more review

It's a similar approached used for post meta in WP core I think.

Adds a wpsc_update_meta_cache( $object_type, $object_ids ) function allowing you to update (and return) object meta for multiple object IDs. Object meta is cached so subsequent calls to wpsc_get_meta() should't result in multiple queries.

Probably just best to check I'm doing this in the most logical place in the WPSC_Countries class or whether it could happen later?
https://github.com/wp-e-commerce/WP-e-Commerce/commit/845e287fd945477dc8b4ff765509766d52fa249c#diff-d28908128b3125f33af2e8aaced63d17R901