### PR TITLE
Add 'wpsc_duplicate_product_thumbnail' filter.

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -1528,7 +1528,7 @@ function wpsc_duplicate_children( $old_parent_id, $new_parent_id ) {
  */
 function wpsc_duplicate_product_image_process( $child_post, $new_parent_id ) {
 
-	if ( 'attachment' == get_post_type( $child_post ) && apply_filters( 'wpsc_duplicate_product_attachment', true, $child_post ) ) {
+	if ( 'attachment' == get_post_type( $child_post ) && apply_filters( 'wpsc_duplicate_product_attachment', true, $child_post, $new_parent_id ) ) {
 
 		$file = wp_get_attachment_url( $child_post->ID );
 

--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -1498,7 +1498,7 @@ function wpsc_duplicate_product_meta( $id, $new_id ) {
  */
 function wpsc_duplicate_product_thumbnail( $post_id, $new_post_id ) {
 
-	$thumbnail_id = has_post_thumbnail( $new_post_id ) ? get_post_thumbnail_id( $new_post_id ) : 0;
+	$thumbnail_id = $original_thumbnail_id = has_post_thumbnail( $new_post_id ) ? get_post_thumbnail_id( $new_post_id ) : 0;
 
 	// If not duplicating product attachments, ensure featured image ID is zero
 	if ( ! apply_filters( 'wpsc_duplicate_product_attachment', true, get_post( $thumbnail_id ), $new_post_id ) ) {
@@ -1506,7 +1506,7 @@ function wpsc_duplicate_product_thumbnail( $post_id, $new_post_id ) {
 	}
 
 	// Filter featured product image ID
-	$thumbnail_id = absint( apply_filters( 'wpsc_duplicate_product_thumbnail', $thumbnail_id, $post_id, $new_post_id ) );
+	$thumbnail_id = absint( apply_filters( 'wpsc_duplicate_product_thumbnail', $thumbnail_id, $original_thumbnail_id, $post_id, $new_post_id ) );
 
 	if ( $thumbnail_id > 0 ) {
 		set_post_thumbnail( $new_post_id, $thumbnail_id );

--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -1493,8 +1493,8 @@ function wpsc_duplicate_product_meta( $id, $new_id ) {
  * the duplicated product and offers the opportunity to change the featured image
  * of the duplicated product via the 'wpsc_duplicate_product_thumbnail' filter.
  *
- * @param   integer  $id      Product ID.
- * @param   integer  $new_id  Duplicated product ID.
+ * @param   integer  $post_id      Product ID.
+ * @param   integer  $new_post_id  Duplicated product ID.
  */
 function wpsc_duplicate_product_thumbnail( $post_id, $new_post_id ) {
 

--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -1583,6 +1583,10 @@ function wpsc_duplicate_product_image_process( $child_post, $new_parent_id ) {
 
 		}
 
+	} elseif ( has_post_thumbnail( $new_parent_id ) && $child_post->ID == get_post_thumbnail_id( $new_parent_id ) ) {
+
+		delete_post_meta( $new_parent_id, '_thumbnail_id' );
+
 	}
 
 }


### PR DESCRIPTION
For issue #1672

When duplicating a product, this is the workflow:

 - Attached images are duplicated to the new product and featured image set.
 - If images are set not to copy via the 'wpsc_duplicate_product_attachment' the featured image is not copied either.

The 'wpsc_duplicate_product_thumbnail' allows you to alter the above outcome.