### PR TITLE
Change download date with file post_date

### DIFF
--- a/wpsc-components/theme-engine-v1/templates/functions/wpsc-user_log_functions.php
+++ b/wpsc-components/theme-engine-v1/templates/functions/wpsc-user_log_functions.php
@@ -638,7 +638,7 @@ function _wpsc_action_downloads_section() {
 			}
 
 			$item['downloads'] = $products[$key]['downloads'];
-			$item['datetime'] = date( get_option( 'date_format' ), strtotime( $products[$key]['datetime'] ) );
+			$item['datetime'] = date( get_option( 'date_format' ), strtotime( $file['post_date'] ) );
 			$items[] = (object) $item;
 		}
 	}


### PR DESCRIPTION
Replaces the date on the Your downloads page to show the date when the file has been uploaded.
Easier for customers to see which file is "latest" perhaps ?