### PR TITLE
Adds additional information to USPS setup section

### DIFF
--- a/wpsc-shipping/usps_20.php
+++ b/wpsc-shipping/usps_20.php
@@ -204,6 +204,7 @@ class ash_usps {
 				<input type='text' name='wpec_usps[id]' value='<?php esc_attr_e( $settings["id"] ); ?>' />
 				<p class='description'><?php printf( __("Don't have a USPS API account? <a href='%s' target='_blank'>Register for USPS Web Tools</a>", 'wpsc' ), 'https://secure.shippingapis.com/registration/' ); ?></p>
 				<p class='description'><?php _e( "Make sure your account has been activated with USPS - if you're unsure if this applies to you then please check with USPS", 'wpsc' ); ?></p>
+				<p class='description'><?php printf( __("Once you've completed integration, <a href='%s' target='_blank'>you'll need to submit a request to promote tools to production</a>.", 'wpsc' ), 'https://www.usps.com/business/web-tools-apis/developers-center.htm#learn-more--1-1' ); ?></p>
 			</td>
 		</tr>
 


### PR DESCRIPTION
Problem:
It's hard to tell why USPS shipping requests are not working in a production environment. WPEC offers some vague information about "activating" the USPS tools. However, when contacted, USPS employees weren't aware of what "activating" the tools meant.

This simple PR just adds some additional information about what to do after you are done setting up the USPS shipping option.

Notes: 
- I haven't made any changes to any of the translation files (mainly because I'm not sure how to translate this appropriately). 
- I yoinked the wording for this right off of the USPS page. Maybe we want better wording then "Once you've completed integration"? I don't know.

/cc: @JustinSainton 