### PR TITLE
Updated wpsc_copy_meta_value_to_similiar to not overwrite default val…

### DIFF
--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -734,7 +734,7 @@ function wpsc_copy_meta_value_to_similiar( element ) {
 				}
 			} else {
 				current_value = jQuery( this ).val();
-				if ( current_value != meta_value ) {
+				if ( current_value != meta_value && meta_value ) {
 					jQuery( this ).val( meta_value );
 				}
 			}


### PR DESCRIPTION
…ues with blank meta_value

What happens is when a user comes to the shipping calculator (checkout) for the very first time the current_country select menus default (selected="selected") is overwritten with the value "".

This may be intentional, but it ignores the default selected value because the actual value (EG: "US") is different from the blank value in the hidden for elements (EG: "").

My proposed change is to make sure that the value is truthy before you go on and set it.