### PR TITLE
Don't output old price HTML if not on sale (instead of hiding it with CSS).

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -1669,6 +1669,11 @@ function wpsc_the_product_price_display( $args = array() ) {
 
 	$show_old_price = $show_you_save = wpsc_product_on_special( $id );
 
+	// Don't output old price HTML if not on sale.
+	if ( ! wpsc_product_on_special( $id ) ) {
+		$output_old_price = $output_you_save = false;
+	}
+
 	// but if the product has variations and at least one of the variations is on special, we have
 	// a few edge cases...
 	if ( wpsc_product_has_variations( $id ) && wpsc_product_on_special( $id ) ) {


### PR DESCRIPTION
Currently there are scenarios where we still output a product's old price in HTML but hide it with CSS when the context isn't relevant.

However, Google sometimes picks this up and shows as part of the description in search results:

![google](https://cloud.githubusercontent.com/assets/765285/9788516/459ecfb4-57c2-11e5-94f2-e11b463d1b35.jpg)

This fixes the issue by only outputting the HTML when it is required:

 * If the product has a sale price
 * If the product has variations and one of the variations has a sale price