### PR TITLE
Wait to initialize payment gateways after the bulk of WPeC is loaded

### DIFF
--- a/wpsc-components/merchant-core-v3/classes/payment-gateway.php
+++ b/wpsc-components/merchant-core-v3/classes/payment-gateway.php
@@ -790,4 +790,4 @@ class WPSC_Payment_Gateway_Setting {
 	}
 }
 
-WPSC_Payment_Gateways::init();
+add_action( 'wpsc_loaded', array( 'WPSC_Payment_Gateways', 'init' ) );


### PR DESCRIPTION
Initialize payment gateways after the bulk of WPeC is loaded so that classes and database initialization has already taken place. Avoids errors thrown because things like countries and currencies are not loaded until all of the wpsc-includes are processed.

Avoids immediate and later php/checkout errors resulting from use of data that isn't loaded until later in the initialization process.