### PR TITLE
Don't hard code completed purchase status values in SQL queries, they can change

### DIFF
--- a/wpsc-admin/admin.php
+++ b/wpsc-admin/admin.php
@@ -768,6 +768,27 @@ function _wpsc_enqueue_wp_e_commerce_admin( ) {
 add_action( 'admin_menu', 'wpsc_admin_pages' );
 
 /**
+ * Get completed purchase status string to use in database queries
+ *
+ * @return string comma delimited string of existing purchase log status that note completed transactions,
+ *                suitable to use in a SQL 'IN' clause to find completed transactions
+ */
+function _wpsc_get_completed_purchase_status_text() {
+	global $wpdb;
+	$sql = "SELECT DISTINCT processed FROM `" . WPSC_TABLE_PURCHASE_LOGS . "`";
+	$statii = $wpdb->get_col( $sql );
+	foreach( $statii as $index => $status ) {
+		if ( ! WPSC_Purchase_Log::is_order_status_completed( $status ) ) {
+			unset( $statii[$index] );
+		}
+	}
+
+	$statii = implode( ',', $statii );
+
+	return $statii;
+}
+
+/**
  * Displays latest activity in the Dashboard widget
  *
  * @uses $wpdb                          WordPress database object for queries
@@ -789,11 +810,14 @@ function wpsc_admin_latest_activity() {
 	echo "<strong class='dashboardHeading'>" . esc_html__( 'Current Month', 'wpsc' ) . "</strong><br />";
 	echo "<p class='dashboardWidgetSpecial'>";
 	// calculates total amount of orders for the month
+
+	$statii = _wpsc_get_completed_purchase_status_text();
+
 	$year = date( "Y" );
 	$month = date( "m" );
 	$start_timestamp = mktime( 0, 0, 0, $month, 1, $year );
 	$end_timestamp = mktime( 0, 0, 0, ( $month + 1 ), 0, $year );
-	$sql = "SELECT COUNT(*) FROM `" . WPSC_TABLE_PURCHASE_LOGS . "` WHERE `date` BETWEEN '$start_timestamp' AND '$end_timestamp' AND `processed` IN (2,3,4) ORDER BY `date` DESC";
+	$sql = "SELECT COUNT(*) FROM `" . WPSC_TABLE_PURCHASE_LOGS . "` WHERE `date` BETWEEN '$start_timestamp' AND '$end_timestamp' AND `processed` IN ($statii) ORDER BY `date` DESC";
 	$currentMonthOrders = $wpdb->get_var( $sql );
 
 	//calculates amount of money made for the month
@@ -1085,12 +1109,13 @@ function wpsc_dashboard_4months_widget() {
 	$months[] = mktime( 0, 0, 0, $this_month - 1, 1, $this_year );
 	$months[] = mktime( 0, 0, 0, $this_month, 1, $this_year );
 
+	$statii = _wpsc_get_completed_purchase_status_text();
 	$products = $wpdb->get_results( "SELECT `cart`.`prodid`,
 	 `cart`.`name`
 	 FROM `" . WPSC_TABLE_CART_CONTENTS . "` AS `cart`
 	 INNER JOIN `" . WPSC_TABLE_PURCHASE_LOGS . "` AS `logs`
 	 ON `cart`.`purchaseid` = `logs`.`id`
-	 WHERE `logs`.`processed` >= 2
+	 WHERE `logs`.`processed` IN ($statii)
 	 AND `logs`.`date` >= " . $months[0] . "
 	 GROUP BY `cart`.`prodid`
 	 ORDER BY SUM(`cart`.`price` * `cart`.`quantity`) DESC
@@ -1107,6 +1132,7 @@ function wpsc_dashboard_4months_widget() {
 	$timeranges[3]["end"] = time(); // using mktime here can generate a php runtime warning
 
 	$prod_data = array( );
+	$statii = _wpsc_get_completed_purchase_status_text();
 	foreach ( (array)$products as $product ) { //run through products and get each product income amounts and name
 		$sale_totals = array( );
 		foreach ( $timeranges as $timerange ) { //run through time ranges of product, and get its income over each time range
@@ -1115,7 +1141,7 @@ function wpsc_dashboard_4months_widget() {
 			FROM `" . WPSC_TABLE_CART_CONTENTS . "` AS `cart`
 			INNER JOIN `" . WPSC_TABLE_PURCHASE_LOGS . "` AS `logs`
 				ON `cart`.`purchaseid` = `logs`.`id`
-			WHERE `logs`.`processed` >= 2
+			WHERE `logs`.`processed` IN ($statii)
 				AND `logs`.`date` >= " . $timerange["start"] . "
 				AND `logs`.`date` < " . $timerange["end"] . "
 				AND `cart`.`prodid` = " . $product['prodid'] . "

--- a/wpsc-includes/processing.functions.php
+++ b/wpsc-includes/processing.functions.php
@@ -201,13 +201,15 @@ function wpsc_get_currency_code(){
 function admin_display_total_price($start_timestamp = '', $end_timestamp = '') {
   global $wpdb;
 
-   if( ( $start_timestamp != '' ) && ( $end_timestamp != '' ) )
-	$sql = $wpdb->prepare( "SELECT SUM(`totalprice`) FROM `".WPSC_TABLE_PURCHASE_LOGS."` WHERE `processed` IN (2,3,4,5) AND `date` BETWEEN %s AND %s", $start_timestamp, $end_timestamp );
-    else
-	$sql = "SELECT SUM(`totalprice`) FROM `".WPSC_TABLE_PURCHASE_LOGS."` WHERE `processed` IN (2,3,4,5) AND `date` != ''";
+   $statii = _wpsc_get_completed_purchase_status_text();
+   if( ( $start_timestamp != '' ) && ( $end_timestamp != '' ) ) {
+	   $sql = $wpdb->prepare( "SELECT SUM(`totalprice`) FROM `" . WPSC_TABLE_PURCHASE_LOGS . "` WHERE `processed` IN ($statii) AND `date` BETWEEN %s AND %s", $start_timestamp, $end_timestamp );
+   } else {
+	   $sql = "SELECT SUM(`totalprice`) FROM `" . WPSC_TABLE_PURCHASE_LOGS . "` WHERE `processed` IN ($statii) AND `date` != ''";
+   }
 
-    $total = $wpdb->get_var($sql);
-  return $total;
+   $total = $wpdb->get_var($sql);
+   return $total;
 }
 
 function wpsc_get_mimetype($file, $check_reliability = false) {


### PR DESCRIPTION
Remove hard coded status values from sql queries checking for completed transactions. Instead identify status values that represent completed transactions.

Necessary because status values can be changed or added using WPeC filters and actions.

Fixes issues that can cause sales totals to be calculated incorrectly
