### PR TITLE
Allow price formatting arguments to be changed with a filter

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -1660,6 +1660,19 @@ function wpsc_the_product_price_display( $args = array() ) {
 	);
 
 	$r = wp_parse_args( $args, $defaults );
+
+	/**
+	 * wpsc_the_product_price_display_args filter args for product price display
+	 *
+	 * Paramters used to format price display can be set globally using this filter
+	 *
+	 * @since 3.9.11
+	 *
+	 * @type array $args array of parameters used to format product price
+	 * @type int $product_id WPeC Product ID for the current product
+
+	 */
+	$r = apply_filters( 'wpsc_the_product_price_display_args', $r, $id, 10, 2 );
 	extract( $r );
 
 	// if the product has no variations, these amounts are straight forward...

--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -1666,13 +1666,13 @@ function wpsc_the_product_price_display( $args = array() ) {
 	 *
 	 * Paramters used to format price display can be set globally using this filter
 	 *
-	 * @since 3.10.1
+	 * @since 4.0
 	 *
 	 * @type array $args array of parameters used to format product price
 	 * @type int $product_id WPeC Product ID for the current product
 
 	 */
-	$r = apply_filters( 'wpsc_the_product_price_display_args', $r, $id, 10, 2 );
+	$r = apply_filters( 'wpsc_the_product_price_display_args', $r, $id );
 	extract( $r );
 
 	// if the product has no variations, these amounts are straight forward...

--- a/wpsc-components/theme-engine-v1/helpers/template-tags.php
+++ b/wpsc-components/theme-engine-v1/helpers/template-tags.php
@@ -1666,7 +1666,7 @@ function wpsc_the_product_price_display( $args = array() ) {
 	 *
 	 * Paramters used to format price display can be set globally using this filter
 	 *
-	 * @since 3.9.11
+	 * @since 3.10.1
 	 *
 	 * @type array $args array of parameters used to format product price
 	 * @type int $product_id WPeC Product ID for the current product


### PR DESCRIPTION
Allow price formatting arguments to be changed with a filter. Avoids a theme developer having to change default theme files to adjust text and formatting of prices. 