### PR TITLE
Remove full width download csv

### DIFF
--- a/wpsc-admin/css/admin.css
+++ b/wpsc-admin/css/admin.css
@@ -1419,7 +1419,6 @@ table.category_forms td.last_row {
 }
 
 a.admin_download {
-	display: block;
 	height: 26px;
 	border-bottom: none;
 	text-decoration: none;


### PR DESCRIPTION
Anoying cause the "href" spread for the whole width of the page. Clicking in the sales log right under Tracking Id would cause the csv generation