### PR TITLE
Make Fancy Notifications into a module.

### DIFF
--- a/wp-shopping-cart.php
+++ b/wp-shopping-cart.php
@@ -87,6 +87,11 @@ class WP_eCommerce {
 				WPSC_FILE_PATH . '/wpsc-components/marketplace-core-v1/marketplace-core-v1.php'
 		);
 
+		$components['fancy-notifications']['fancy-notifications-v1'] = array(
+			'title'    => __( 'Fancy Notifications v1', 'wpsc' ),
+			'includes' => WPSC_FILE_PATH . '/wpsc-components/fancy-notifications/fancy-notifications.php'
+		);
+
 		return $components;
 	}
 

--- a/wpsc-components/fancy-notifications/css/fancy-notifications.css
+++ b/wpsc-components/fancy-notifications/css/fancy-notifications.css
@@ -1,0 +1,41 @@
+
+/**
+ * WP eCommerce Fancy Notifications CSS
+ */
+
+#fancy_notification {
+	position: absolute;
+	top: 0;
+	left: 0;
+	background: #fff;
+	border: 4px solid #ccc;
+	display: none;
+	height: auto;
+	z-index: 9;
+}
+
+#fancy_notification #loading_animation {
+	display: none;
+}
+
+#fancy_notification #fancy_notification_content {
+	display: none;
+	width: 300px;
+	height: auto;
+	padding: 8px;
+	text-align: left;
+	margin: 0 !important;
+}
+
+#fancy_notification #fancy_notification_content span {
+	margin: 0 0 6px 0;
+	display: block;
+	font-weight: normal;
+}
+
+#fancy_notification #fancy_notification_content a {
+	display: block;
+	float: left;
+	margin-right: 6px;
+	margin-bottom: 3px;
+}

--- a/wpsc-components/fancy-notifications/fancy-notifications.php
+++ b/wpsc-components/fancy-notifications/fancy-notifications.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * WP eCommerce Fancy Notifications
+ */
+
+add_action( 'wp_enqueue_scripts', array( 'WPSC_Fancy_Notifications', 'enqueue_styles' ) );
+add_action( 'wp_enqueue_scripts', array( 'WPSC_Fancy_Notifications', 'enqueue_scripts' ) );
+add_action( 'wpsc_add_to_cart_button_form_begin', array( 'WPSC_Fancy_Notifications', 'add_fancy_notifications' ) );
+add_action( 'wpsc_theme_footer', array( 'WPSC_Fancy_Notifications', 'fancy_notifications' ) );
+add_filter( 'wpsc_add_to_cart_json_response', array( 'WPSC_Fancy_Notifications', 'wpsc_add_to_cart_json_response' ) );
+
+/**
+ * WP eCommerce Fancy Notifications Class
+ */
+class WPSC_Fancy_Notifications {
+
+	/**
+	 * Fancy Notifications
+	 *
+	 * Container HTML for fancy notifications.
+	 *
+	 * @param   boolean  $return  Return output.
+	 * @return  string            Output.
+	 */
+	public static function fancy_notifications( $return = false ) {
+
+		static $already_output = false;
+
+		if ( $already_output ) {
+			return '';
+		}
+
+		$output = '';
+		if ( 1 == get_option( 'fancy_notifications' ) ) {
+			$output .= '<div id="fancy_notification">';
+			$output .= '   <div id="loading_animation">';
+			$output .= '      <img id="fancy_notificationimage" title="' . esc_attr__( 'Loading', 'wpsc' ) . '" alt="' . esc_attr__( 'Loading', 'wpsc' ) . '" src="' . esc_url( wpsc_loading_animation_url() ) . '" />' . esc_html__( 'Updating', 'wpsc' ) . '...';
+			$output .= '   </div>';
+			$output .= '   <div id="fancy_notification_content"></div>';
+			$output .= '</div>';
+		}
+
+		$already_output = true;
+
+		if ( $return ) {
+			return $output;
+		}
+		echo $output;
+
+	}
+
+	/**
+	 * Fancy Notification Content
+	 *
+	 * @param   array   $cart_messages  Cart message.
+	 * @return  string                  Fancy notification content.
+	 */
+	public static function fancy_notification_content( $cart_messages ) {
+
+		$siteurl = get_option( 'siteurl' );
+
+		$output = '';
+		foreach ( (array)$cart_messages as $cart_message ) {
+			$output .= '<span>' . $cart_message . '</span><br />';
+		}
+		$output .= sprintf( '<a href="%s" class="go_to_checkout">%s</a>', esc_url( get_option( 'shopping_cart_url' ) ), esc_html__( 'Go to Checkout', 'wpsc' ) );
+		$output .= sprintf( '<a href="#" onclick="jQuery( \'#fancy_notification\' ).css( \'display\', \'none\' ); return false;" class="continue_shopping">%s</a>', esc_html__( 'Continue Shopping', 'wpsc' ) );
+
+		return $output;
+
+	}
+
+	/**
+	 * Add To Cart JSON Response
+	 *
+	 * Adds 'fancy_notification' content to JSON response.
+	 *
+	 * @param   array  $json_response  JSON response.
+	 * @return  array                  Updated JSON response.
+	 */
+	public static function wpsc_add_to_cart_json_response( $json_response ) {
+
+		if ( is_numeric( $json_response['product_id'] ) && 1 == get_option( 'fancy_notifications' ) ) {
+			$json_response['fancy_notification'] = str_replace( array( "\n", "\r" ), array( '\n', '\r' ), self::fancy_notification_content( $json_response['cart_messages'] ) );
+		}
+
+		return $json_response;
+
+	}
+
+	/**
+	 * Add Fancy Notifications
+	 */
+	public static function add_fancy_notifications() {
+
+		add_action( 'wp_footer', array( 'WPSC_Fancy_Notifications', 'fancy_notifications' ) );
+
+	}
+
+	/**
+	 * Enqueue Styles
+	 */
+	public static function enqueue_styles() {
+
+		wp_enqueue_style( 'wpsc-fancy-notifications', self::plugin_url() . '/css/fancy-notifications.css', false, '1.0' );
+
+	}
+
+	/**
+	 * Enqueue Scripts
+	 */
+	public static function enqueue_scripts() {
+
+		wp_enqueue_script( 'wpsc-fancy-notifications', self::plugin_url() . '/js/fancy-notifications.js', array( 'jquery' ), '1.0' );
+
+	}
+
+	/**
+	 * Plugin URL
+	 *
+	 * @return  string  URL for fancy notifications directory.
+	 */
+	public static function plugin_url() {
+
+		return plugins_url( '', __FILE__ );
+
+	}
+
+}

--- a/wpsc-components/fancy-notifications/js/fancy-notifications.js
+++ b/wpsc-components/fancy-notifications/js/fancy-notifications.js
@@ -21,7 +21,7 @@ var WPEC_Fancy_Notifications;
 		/**
 		 * Fancy Notification: Show
 		 */
-		wpscAddToBasket : function( e ) {
+		wpscAddToCart : function( e ) {
 
 			$( 'div.wpsc_loading_animation' ).css( 'visibility', 'hidden' );
 			WPEC_Fancy_Notifications.fancy_notification( e.form );
@@ -57,7 +57,7 @@ var WPEC_Fancy_Notifications;
 		/**
 		 * Fancy Notification: Hide
 		 */
-		wpscAddedToBasket : function( e ) {
+		wpscAddedToCart : function( e ) {
 
 			if ( ( e.response ) ) {
 				if ( e.response.hasOwnProperty( 'fancy_notification' ) && e.response.fancy_notification ) {
@@ -82,7 +82,7 @@ var WPEC_Fancy_Notifications;
 	 * Event Handlers
 	 */
 	$( document ).on( 'ready', WPEC_Fancy_Notifications.appendToBody );
-	$( document ).on( 'wpscAddToBasket', WPEC_Fancy_Notifications.wpscAddToBasket );
-	$( document ).on( 'wpscAddedToBasket', WPEC_Fancy_Notifications.wpscAddedToBasket );
+	$( document ).on( 'wpscAddToCart', WPEC_Fancy_Notifications.wpscAddToCart );
+	$( document ).on( 'wpscAddedToCart', WPEC_Fancy_Notifications.wpscAddedToCart );
 
 } ) ( jQuery );

--- a/wpsc-components/fancy-notifications/js/fancy-notifications.js
+++ b/wpsc-components/fancy-notifications/js/fancy-notifications.js
@@ -1,0 +1,88 @@
+
+/**
+ * WP eCommerce Fancy Notifications JS
+ */
+
+var WPEC_Fancy_Notifications;
+
+( function( $ ) {
+
+	WPEC_Fancy_Notifications = {
+
+		/**
+		 * Move Fancy Notification element to end of HTML body.
+		 */
+		appendToBody : function() {
+
+			$( '#fancy_notification' ).appendTo( 'body' );
+
+		},
+
+		/**
+		 * Fancy Notification: Show
+		 */
+		wpscAddToBasket : function( e ) {
+
+			$( 'div.wpsc_loading_animation' ).css( 'visibility', 'hidden' );
+			WPEC_Fancy_Notifications.fancy_notification( e.form );
+
+		},
+
+		/**
+		 * Fancy Notification
+		 *
+		 * @param  object  parent_form  Form element.
+		 */
+		fancy_notification : function( parent_form ) {
+
+			var fancyNotificationEl = $( '#fancy_notification' );
+
+			if ( typeof( WPSC_SHOW_FANCY_NOTIFICATION ) == 'undefined' ) {
+				WPSC_SHOW_FANCY_NOTIFICATION = true;
+			}
+
+			if ( ( WPSC_SHOW_FANCY_NOTIFICATION === true ) && ( fancyNotificationEl !== null ) ) {
+				fancyNotificationEl.css( {
+					display  : 'block',
+					position : 'fixed',
+					left     : ( $( window ).width() - fancyNotificationEl.outerWidth() ) / 2,
+					top      : ( $( window ).height() - fancyNotificationEl.outerHeight() ) / 2
+				} );
+				$( '#loading_animation' ).css( 'display', 'block' );
+				$( '#fancy_notification_content' ).css( 'display', 'none' );
+			}
+
+		},
+
+		/**
+		 * Fancy Notification: Hide
+		 */
+		wpscAddedToBasket : function( e ) {
+
+			if ( ( e.response ) ) {
+				if ( e.response.hasOwnProperty( 'fancy_notification' ) && e.response.fancy_notification ) {
+					if ( $( '#fancy_notification_content' ) ) {
+						$( '#fancy_notification_content' ).html( e.response.fancy_notification );
+						$( '#loading_animation').css( 'display', 'none' );
+						$( '#fancy_notification_content' ).css( 'display', 'block' );
+					}
+				}
+				$( document ).trigger( { type : 'wpsc_fancy_notification', response : e.response } );
+			}
+
+			if ( $( '#fancy_notification' ).length > 0 ) {
+				$( '#loading_animation' ).css( 'display', 'none' );
+			}
+
+		}
+
+	};
+
+	/**
+	 * Event Handlers
+	 */
+	$( document ).on( 'ready', WPEC_Fancy_Notifications.appendToBody );
+	$( document ).on( 'wpscAddToBasket', WPEC_Fancy_Notifications.wpscAddToBasket );
+	$( document ).on( 'wpscAddedToBasket', WPEC_Fancy_Notifications.wpscAddedToBasket );
+
+} ) ( jQuery );

--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -184,11 +184,6 @@ function wpsc_add_to_cart() {
 		$output = _wpsc_ajax_get_cart( false, $cart_messages );
 
 		$json_response = $json_response + $output;
-
-		if ( is_numeric( $product_id ) && 1 == get_option( 'fancy_notifications' ) ) {
-			$json_response['fancy_notification'] = str_replace( array( "\n", "\r" ), array( '\n', '\r' ), fancy_notification_content( $cart_messages ) );
-		}
-
 		$json_response = apply_filters( 'wpsc_add_to_cart_json_response', $json_response );
 
 		die( json_encode( $json_response ) );
@@ -241,13 +236,17 @@ function wpsc_add_to_cart_button( $product_id, $return = false ) {
 	}
 }
 
-/* 19-02-09
- * add to cart shortcode function used for shortcodes calls the function in
+/**
+ * Add to cart shortcode function used for shortcodes calls the function in
  * product_display_functions.php
+ *
+ * @since  19-02-09
+ *
+ * Note: Really old legacy shortcode support for add to cart buttons.
+ * This isn't a proper WordPress shortcode!
  */
-
 function add_to_cart_shortcode( $content = '' ) {
-	static $fancy_notification_output = false;
+
 	if ( ! in_the_loop() )
 		return $content;
 
@@ -256,11 +255,6 @@ function add_to_cart_shortcode( $content = '' ) {
 			$original_string = $matches[0][$key];
 			$output = wpsc_add_to_cart_button( $product_id, true );
 			$content = str_replace( $original_string, $output, $content );
-		}
-
-		if ( ! $fancy_notification_output ) {
-			$content .= wpsc_fancy_notifications( true );
-			$fancy_notification_output = true;
 		}
 	}
 	return $content;

--- a/wpsc-components/theme-engine-v1/helpers/product.php
+++ b/wpsc-components/theme-engine-v1/helpers/product.php
@@ -1,6 +1,5 @@
 <?php
 add_action( 'save_post'        , 'wpsc_refresh_page_urls', 10, 2 );
-add_action( 'wpsc_theme_footer', 'wpsc_fancy_notifications' );
 
 if ( get_option( 'wpsc_replace_page_title' ) == 1 ) {
 	add_filter( 'wp_title', 'wpsc_replace_wp_title', 10, 2 );
@@ -772,46 +771,6 @@ function wpsc_also_bought( $product_id ) {
  */
 function wpsc_loading_animation_url() {
 	return apply_filters( 'wpsc_loading_animation_url', WPSC_CORE_THEME_URL . 'wpsc-images/indicator.gif' );
-}
-
-function fancy_notifications() {
-	return wpsc_fancy_notifications( true );
-}
-function wpsc_fancy_notifications( $return = false ) {
-	static $already_output = false;
-
-	if ( $already_output )
-		return '';
-
-	$output = "";
-	if ( get_option( 'fancy_notifications' ) == 1 ) {
-		$output = "";
-		$output .= "<div id='fancy_notification'>\n\r";
-		$output .= "  <div id='loading_animation'>\n\r";
-		$output .= '<img id="fancy_notificationimage" title="' . esc_attr__( 'Loading', 'wp-e-commerce' ) . '" alt="' . esc_attr__( 'Loading', 'wp-e-commerce' ) . '" src="' . wpsc_loading_animation_url() . '" />' . __( 'Updating', 'wp-e-commerce' ) . "...\n\r";
-		$output .= "  </div>\n\r";
-		$output .= "  <div id='fancy_notification_content'>\n\r";
-		$output .= "  </div>\n\r";
-		$output .= "</div>\n\r";
-	}
-
-	$already_output = true;
-
-	if ( $return )
-		return $output;
-	else
-		echo $output;
-}
-
-function fancy_notification_content( $cart_messages ) {
-	$siteurl = get_option( 'siteurl' );
-	$output = '';
-	foreach ( (array)$cart_messages as $cart_message ) {
-		$output .= "<span>" . $cart_message . "</span><br />";
-	}
-	$output .= "<a href='" . get_option( 'shopping_cart_url' ) . "' class='go_to_checkout'>" . __( 'Go to Checkout', 'wp-e-commerce' ) . "</a>";
-	$output .= "<a href='#' onclick='jQuery(\"#fancy_notification\").css(\"display\", \"none\"); return false;' class='continue_shopping'>" . __( 'Continue Shopping', 'wp-e-commerce' ) . "</a>";
-	return $output;
 }
 
 /*

--- a/wpsc-components/theme-engine-v1/templates/wpsc-default.css
+++ b/wpsc-components/theme-engine-v1/templates/wpsc-default.css
@@ -652,39 +652,6 @@ span.rating_saved{
 	color: #990000;
 	display: none;
 }
-/*-----FANCY NOTIFICATION STYLING-----*/
-#fancy_notification{
-	position: absolute;
-	top: 0;
-	left: 0;
-	background: #ffffff;
-	border: 4px solid #cccccc;
-	display: none;
-	height: auto;
-	z-index: 9;
-}
-#fancy_notification #loading_animation{
-	display: none;
-}
-#fancy_notification #fancy_notification_content{
-	display: none;
-	width: 300px;
-	padding: 8px;
-	height: auto;
-	text-align: left;
-	margin: 0 !important;
-}
-#fancy_notification #fancy_notification_content span{
-	margin: 0 0 6px 0;
-	display: block;
-	font-weight: normal;
-}
-#fancy_notification #fancy_notification_content a{
-	display: block;
-	float: left;
-	margin-right: 6px;
-	margin-bottom: 3px;
-}
 
 /*-----SHOPPING CART-----*/
 .shopping-cart-wrapper {

--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -1101,8 +1101,6 @@ jQuery(document).ready(function ($) {
 		jQuery('#wpsc_checkout_gravatar').attr('src', 'https://secure.gravatar.com/avatar/'+MD5(jQuery(this).val().split(' ').join(''))+'?s=60&d=mm');
 	});
 
-	jQuery('#fancy_notification').appendTo('body');
-
 	/* Clears shipping state and billing state on body load if they are numeric */
 	$( 'input[title="shippingstate"], input[title="billingstate"]' ).each( function( index, value ){
 		var $this = $( this ), $val = $this.val();
@@ -1159,29 +1157,6 @@ jQuery(document).ready(function ($) {
 			return false;
 		}
 	});
-
-	// Fancy Notification: Show
-	jQuery( document ).on( 'wpscAddToBasket', function( e ) {
-		jQuery( 'div.wpsc_loading_animation' ).css( 'visibility', 'hidden' );
-		wpsc_fancy_notification( e.form );
-	} );
-
-	// Fancy Notification: Hide
-	jQuery( document ).on( 'wpscAddedToBasket', function( e ) {
-		if ( ( e.response ) ) {
-			if ( e.response.hasOwnProperty( 'fancy_notification' ) && e.response.fancy_notification ) {
-				if ( jQuery( '#fancy_notification_content' ) ) {
-					jQuery( '#fancy_notification_content' ).html( e.response.fancy_notification );
-					jQuery( '#loading_animation').css( 'display', 'none' );
-					jQuery( '#fancy_notification_content' ).css( 'display', 'block' );
-				}
-			}
-			jQuery( document ).trigger( { type : 'wpsc_fancy_notification', response : e.response } );
-		}
-		if ( jQuery( '#fancy_notification' ).length > 0 ) {
-			jQuery( '#loading_animation' ).css( 'display', 'none' );
-		}
-	} );
 
 	jQuery( 'a.wpsc_category_link, a.wpsc_category_image_link' ).click(function(){
 		product_list_count = jQuery.makeArray(jQuery('ul.category-product-list'));
@@ -1367,22 +1342,17 @@ function submit_change_country(){
 	document.forms.change_country.submit();
 }
 
-// submit the fancy notifications forms.
-function wpsc_fancy_notification(parent_form){
-	if(typeof(WPSC_SHOW_FANCY_NOTIFICATION) == 'undefined'){
-		WPSC_SHOW_FANCY_NOTIFICATION = true;
-	}
-	if((WPSC_SHOW_FANCY_NOTIFICATION === true) && (jQuery('#fancy_notification') !== null)){
-		jQuery('#fancy_notification').css({
-		        position:'fixed',
-		        left: (jQuery(window).width() - jQuery('#fancy_notification').outerWidth())/2,
-		        top: (jQuery(window).height() - jQuery('#fancy_notification').outerHeight())/2
-		    });
+/**
+ * Submit the fancy notifications forms.
+ *
+ * @deprecated  Use WPEC_Fancy_Notifications.fancy_notification() instead.
+ *
+ * @param  object  parent_form  Form element.
+ */
+function wpsc_fancy_notification( parent_form ) {
 
-		jQuery('#fancy_notification').css("display", 'block');
-		jQuery('#loading_animation').css("display", 'block');
-		jQuery('#fancy_notification_content').css("display", 'none');
-	}
+	console.log( 'wpsc_fancy_notification() is deprecated. Use WPEC_Fancy_Notifications.fancy_notification() instead.' );
+
 }
 
 function shopping_cart_collapser() {

--- a/wpsc-core/js/wp-e-commerce.js
+++ b/wpsc-core/js/wp-e-commerce.js
@@ -1132,44 +1132,56 @@ jQuery(document).ready(function ($) {
 
 			form_values = jQuery(this).serialize() + '&action=' + action;
 
-			// Sometimes jQuery returns an object instead of null, using length tells us how many elements are in the object, which is more reliable than comparing the object to null
-			if ( jQuery( '#fancy_notification' ).length === 0 ) {
-				jQuery( 'div.wpsc_loading_animation', this ).css( 'visibility', 'visible' );
-			}
+			jQuery( 'div.wpsc_loading_animation', this ).css( 'visibility', 'visible' );
 
 			var success = function( response ) {
 				if ( ( response ) ) {
-					if ( response.hasOwnProperty('fancy_notification') && response.fancy_notification ) {
-						if ( jQuery( '#fancy_notification_content' ) ) {
-							jQuery( '#fancy_notification_content' ).html( response.fancy_notification );
-							jQuery( '#loading_animation').css( 'display', 'none' );
-							jQuery( '#fancy_notification_content' ).css( 'display', 'block' );
-						}
-					}
 					jQuery('div.shopping-cart-wrapper').html( response.widget_output );
 					jQuery('div.wpsc_loading_animation').css('visibility', 'hidden');
 
 					jQuery( '.cart_message' ).delay( 3000 ).slideUp( 500 );
 
-					//Until we get to an acceptable level of education on the new custom event - this is probably necessary for plugins.
+					// Until we get to an acceptable level of education on the new custom event - this is probably necessary for plugins.
 					if ( response.wpsc_alternate_cart_html ) {
 						eval( response.wpsc_alternate_cart_html );
 					}
 
-					jQuery( document ).trigger( { type : 'wpsc_fancy_notification', response : response } );
 				}
 
-				if ( jQuery( '#fancy_notification' ).length > 0 ) {
-					jQuery( '#loading_animation' ).css( "display", 'none' );
-				}
+				jQuery( document ).trigger( { 'type' : 'wpscAddedToBasket', 'response' : response } );
+
 			};
+
+			jQuery( document ).trigger( { 'type' : 'wpscAddToBasket', 'form' : this } );
 
 			jQuery.post( wpsc_ajax.ajaxurl, form_values, success, 'json' );
 
-			wpsc_fancy_notification(this);
 			return false;
 		}
 	});
+
+	// Fancy Notification: Show
+	jQuery( document ).on( 'wpscAddToBasket', function( e ) {
+		jQuery( 'div.wpsc_loading_animation' ).css( 'visibility', 'hidden' );
+		wpsc_fancy_notification( e.form );
+	} );
+
+	// Fancy Notification: Hide
+	jQuery( document ).on( 'wpscAddedToBasket', function( e ) {
+		if ( ( e.response ) ) {
+			if ( e.response.hasOwnProperty( 'fancy_notification' ) && e.response.fancy_notification ) {
+				if ( jQuery( '#fancy_notification_content' ) ) {
+					jQuery( '#fancy_notification_content' ).html( e.response.fancy_notification );
+					jQuery( '#loading_animation').css( 'display', 'none' );
+					jQuery( '#fancy_notification_content' ).css( 'display', 'block' );
+				}
+			}
+			jQuery( document ).trigger( { type : 'wpsc_fancy_notification', response : e.response } );
+		}
+		if ( jQuery( '#fancy_notification' ).length > 0 ) {
+			jQuery( '#loading_animation' ).css( 'display', 'none' );
+		}
+	} );
 
 	jQuery( 'a.wpsc_category_link, a.wpsc_category_image_link' ).click(function(){
 		product_list_count = jQuery.makeArray(jQuery('ul.category-product-list'));

--- a/wpsc-core/wpsc-deprecated.php
+++ b/wpsc-core/wpsc-deprecated.php
@@ -2354,3 +2354,48 @@ function wpsc_duplicate_product_image_process( $child_post, $new_parent_id ) {
 	$duplicate->duplicate_product_image_process();
 
 }
+
+/**
+ * Fancy Notifications
+ *
+ * @deprecated
+ */
+function fancy_notifications() {
+
+	_wpsc_deprecated_function( __FUNCTION__, '4.0', 'WPSC_Fancy_Notifications::fancy_notifications' );
+
+	WPSC_Fancy_Notifications::fancy_notifications();
+
+}
+
+/**
+ * Fancy Notifications
+ *
+ * @deprecated
+ */
+function wpsc_fancy_notifications( $return = false ) {
+
+	_wpsc_deprecated_function( __FUNCTION__, '4.0', 'WPSC_Fancy_Notifications::fancy_notifications' );
+
+	$fancy_notifications = WPSC_Fancy_Notifications::fancy_notifications( true );
+
+	if ( $return ) {
+		return $fancy_notifications;
+	}
+
+	echo $fancy_notifications;
+
+}
+
+/**
+ * Fancy Notification Content
+ *
+ * @deprecated
+ */
+function fancy_notification_content( $cart_messages ) {
+
+	_wpsc_deprecated_function( __FUNCTION__, '4.0', 'WPSC_Fancy_Notifications::fancy_notification_content' );
+
+	return WPSC_Fancy_Notifications::fancy_notification_content( $cart_messages );
+
+}

--- a/wpsc-includes/wpsc-theme-engine-bootstrap.php
+++ b/wpsc-includes/wpsc-theme-engine-bootstrap.php
@@ -56,7 +56,6 @@ function _wpsc_theme_engine_v1_has_actions() {
 	 */
 	$core_exceptions = array(
 		'wpsc_start_display_user_log_form_fields'    => 'wpsc_deprecated_filter_user_log_get',
-		'wpsc_theme_footer'                          => 'wpsc_fancy_notifications',
 		'wpsc_before_shipping_of_shopping_cart'      => array( '_wpsc_calculate_shipping_quotes_before_product_page', '_wpsc_action_init_shipping_method' ),
 		'wpsc_before_form_of_shopping_cart'          => '_wpsc_shipping_error_messages',
 		'wpsc_user_profile_section_purchase_history' => '_wpsc_action_purchase_history_section',

--- a/wpsc-theme/wpsc-default.css
+++ b/wpsc-theme/wpsc-default.css
@@ -655,44 +655,6 @@ span.rating_saved{
 	display: none;
 }
 
-/*-----FANCY NOTIFICATION STYLING-----*/
-#fancy_notification{
-	position: absolute;
-	top: 0;
-	left: 0;
-	background: #ffffff;
-	border: 4px solid #cccccc;
-	display: none;
-	height: auto;
-	z-index: 9;
-}
-
-#fancy_notification #loading_animation{
-	display: none;
-}
-
-#fancy_notification #fancy_notification_content{
-	display: none;
-	width: 300px;
-	padding: 8px;
-	height: auto;
-	text-align: left;
-	margin: 0 !important;
-}
-
-#fancy_notification #fancy_notification_content span{
-	margin: 0 0 6px 0;
-	display: block;
-	font-weight: normal;
-}
-
-#fancy_notification #fancy_notification_content a{
-	display: block;
-	float: left;
-	margin-right: 6px;
-	margin-bottom: 3px;
-}
-
 /*-----SHOPPING CART-----*/
 .shopping-cart-wrapper {
 	line-height:1.2em;


### PR DESCRIPTION
This moves all Fancy Notification functionality to a self contained module. 

It will act as a good basis for integration withe the V2 Theme engine #2007, or splitting into a separate plugin if required.

This PR is rebased to work with WP eCommerce 3.11.0