### PR TITLE
If previewing a product, ensure post status can be draft.

### DIFF
--- a/wpsc-components/theme-engine-v1/helpers/page.php
+++ b/wpsc-components/theme-engine-v1/helpers/page.php
@@ -580,6 +580,11 @@ function wpsc_single_template( $content ) {
 		 */
 		$permitted_post_statuses = current_user_can( $post_type_object->cap->edit_posts ) ? apply_filters( 'wpsc_product_display_status', array( 'publish' ) ) : array( 'publish' );
 
+		// If previewing a product, ensure post status can be draft
+		if ( $wp_query->is_preview() ) {
+			$permitted_post_statuses[] = 'draft';
+		}
+
 		$wpsc_temp_query = new WP_Query(
 			array(
 				'p'              => $wp_query->post->ID ,


### PR DESCRIPTION
For issue #2044

A while back we were showing draft products on the fronted automatically when logged in as admin.  
We introduced a filter so that this functionality could be toggled as it was not expected default behaviour - draft posts don't show on fronted when logged in for example.

The consequence of this is the default post status was set to publish but this didn't take into account if a draft product was being previewed on the front end - publish status was overriding the preview draft status.

This PR fixes that.