### PR TITLE
Re-name PHP4 constructors to PHP5-style. Add some visibility keywords.

### DIFF
--- a/wpsc-admin/includes/product-functions.php
+++ b/wpsc-admin/includes/product-functions.php
@@ -1073,7 +1073,7 @@ class wpsc_variation_combinator {
 	var $reprocessed_array = array();
 	var $combinations= array();
 
-function wpsc_variation_combinator($variation_sets) {
+public function __construct($variation_sets) {
 	if( $variation_sets ) {
 		foreach($variation_sets as $variation_set_id => $variation_set) {
 			$this->variation_sets[] = absint($variation_set_id);

--- a/wpsc-components/merchant-core-v2/classes/wpsc-gateways.php
+++ b/wpsc-components/merchant-core-v2/classes/wpsc-gateways.php
@@ -11,7 +11,7 @@ class wpsc_gateways {
 	var $current_gateway = -1;
 	var $in_the_loop = false;
 
-	function wpsc_gateways() {
+	public function __construct() {
 		global $nzshpcrt_gateways;
 
 		$gateway_options = get_option( 'custom_gateway_options' );
@@ -32,20 +32,20 @@ class wpsc_gateways {
 	/**
 	 * checkout loop methods
 	 */
-	function next_gateway() {
+	public function next_gateway() {
 		$this->current_gateway++;
 		$this->gateway = $this->wpsc_gateways[$this->current_gateway];
 		return $this->gateway;
 	}
 
-	function the_gateway() {
+	public function the_gateway() {
 		$this->in_the_loop = true;
 		$this->gateway = $this->next_gateway();
 		if ( $this->current_gateway == 0 ) // loop has just started
 			do_action( 'wpsc_checkout_loop_start' );
 	}
 
-	function have_gateways() {
+	public function have_gateways() {
 		if ( $this->current_gateway + 1 < $this->gateway_count ) {
 			return true;
 		} else if ( $this->current_gateway + 1 == $this->gateway_count && $this->gateway_count > 0 ) {
@@ -58,7 +58,7 @@ class wpsc_gateways {
 		return false;
 	}
 
-	function rewind_gateways() {
+	public function rewind_gateways() {
 		$this->current_gateway = -1;
 		if ( $this->gateway_count > 0 ) {
 			$this->gateway = $this->wpsc_gateways[0];

--- a/wpsc-components/theme-engine-v1/classes/breadcrumbs.php
+++ b/wpsc-components/theme-engine-v1/classes/breadcrumbs.php
@@ -201,7 +201,7 @@ class wpsc_breadcrumbs {
 	 * @access public
 	 * @return void
 	 */
-	function wpsc_breadcrumbs() {
+	public function __construct() {
 		global $wp_query, $wpsc_query;
 		$this->breadcrumbs = array();
 		$query_data = Array();
@@ -260,7 +260,7 @@ class wpsc_breadcrumbs {
 	 * @access public
 	 * @return void
 	 */
-	function next_breadcrumbs() {
+	public function next_breadcrumbs() {
 		$this->current_breadcrumb++;
 		$this->breadcrumb = $this->breadcrumbs[$this->current_breadcrumb];
 		return $this->breadcrumb;
@@ -273,7 +273,7 @@ class wpsc_breadcrumbs {
 	 * @access public
 	 * @return void
 	 */
-	function the_breadcrumb() {
+	public function the_breadcrumb() {
 		$this->breadcrumb = $this->next_breadcrumbs();
 	}
 
@@ -283,7 +283,7 @@ class wpsc_breadcrumbs {
 	 * @access public
 	 * @return void
 	 */
-	function have_breadcrumbs() {
+	public function have_breadcrumbs() {
 		if ($this->current_breadcrumb + 1 < $this->breadcrumb_count) {
 			return true;
 		} else if ($this->current_breadcrumb + 1 == $this->breadcrumb_count && $this->breadcrumb_count > 0) {
@@ -298,7 +298,7 @@ class wpsc_breadcrumbs {
 	 * @access public
 	 * @return void
 	 */
-	function rewind_breadcrumbs() {
+	public function rewind_breadcrumbs() {
 		$this->current_breadcrumb = -1;
 		if ($this->breadcrumb_count > 0) {
 			$this->breadcrumb = $this->breadcrumbs[0];

--- a/wpsc-components/theme-engine-v1/classes/wpsc-products-by-category.php
+++ b/wpsc-components/theme-engine-v1/classes/wpsc-products-by-category.php
@@ -14,7 +14,7 @@ class wpsc_products_by_category {
 	 * @param mixed $query
 	 * @return void
 	 */
-	function wpsc_products_by_category( $query ) {
+	function __construct( $query ) {
 
 		_wpsc_doing_it_wrong( 'wpsc_products_by_category', __( 'This class is deprecated. There is no direct replacement. Hiding subcategory products in parent categories is now handled by the private wpsc_hide_subcatsprods_in_cat_query() function.', 'wp-e-commerce' ), '4.0' );
 

--- a/wpsc-components/theme-engine-v1/widgets/shopping_cart_widget.php
+++ b/wpsc-components/theme-engine-v1/widgets/shopping_cart_widget.php
@@ -12,7 +12,7 @@ class WP_Widget_Shopping_Cart extends WP_Widget {
 	/**
 	 * Widget Constuctor
 	 */
-	function WP_Widget_Shopping_Cart() {
+	public function __construct() {
 
 		$widget_ops = array(
 			'classname'   => 'widget_wpsc_shopping_cart',
@@ -30,7 +30,7 @@ class WP_Widget_Shopping_Cart extends WP_Widget {
 	 * @param $instance (array) Widget values.
 	 *
 	 */
-	function widget( $args, $instance ) {
+	public function widget( $args, $instance ) {
 
 		extract( $args );
 
@@ -101,7 +101,7 @@ class WP_Widget_Shopping_Cart extends WP_Widget {
 	 *
 	 * @return (array) New values.
 	 */
-	function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) {
 
 		$instance = $old_instance;
 		$instance['title']  = strip_tags( $new_instance['title'] );
@@ -114,7 +114,7 @@ class WP_Widget_Shopping_Cart extends WP_Widget {
 	 *
 	 * @param $instance (array) Widget values.
 	 */
-	function form( $instance ) {
+	public function form( $instance ) {
 		global $wpdb;
 
 		// Defaults

--- a/wpsc-components/theme-engine-v1/widgets/specials_widget.php
+++ b/wpsc-components/theme-engine-v1/widgets/specials_widget.php
@@ -12,7 +12,7 @@ class WP_Widget_Product_Specials extends WP_Widget {
 	/**
 	 * Widget Constuctor
 	 */
-	function WP_Widget_Product_Specials() {
+	public function __construct() {
 
 		$widget_ops = array(
 			'classname'   => 'widget_wpsc_product_specials',
@@ -31,7 +31,7 @@ class WP_Widget_Product_Specials extends WP_Widget {
 	 *
 	 * @todo Add individual capability checks for each menu item rather than just manage_options.
 	 */
-	function widget( $args, $instance ) {
+	public function widget( $args, $instance ) {
 
 		global $wpdb, $table_prefix;
 
@@ -55,7 +55,7 @@ class WP_Widget_Product_Specials extends WP_Widget {
 	 *
 	 * @return (array) New values.
 	 */
-	function update( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) {
 
 		$instance = $old_instance;
 		$instance['title']            = strip_tags( $new_instance['title'] );
@@ -74,7 +74,7 @@ class WP_Widget_Product_Specials extends WP_Widget {
 	 *
 	 * @param $instance (array) Widget values.
 	 */
-	function form( $instance ) {
+	public function form( $instance ) {
 
 		global $wpdb;
 

--- a/wpsc-core/wpsc-deprecated.php
+++ b/wpsc-core/wpsc-deprecated.php
@@ -483,7 +483,7 @@ function wpsc_total_product_count() {
  *
  */
 class WPSC_Query extends WP_Query {
-	function WPSC_Query( $query = '' ) {
+	public function __construct( $query = '' ) {
 		_wpsc_deprecated_function( __FUNCTION__, '3.8', 'WP_Query()' );
 		$query = wp_parse_args( $query );
 		$query['post_type'] = 'wpsc-product';

--- a/wpsc-includes/cart.class.php
+++ b/wpsc-includes/cart.class.php
@@ -90,7 +90,7 @@ class wpsc_cart {
 	public $_signature = '';
 
 
-    function wpsc_cart() {
+    public function __construct() {
 		$coupon = 'percentage';
 		$this->update_location();
 		$this->wpsc_refresh_cart_items();

--- a/wpsc-includes/checkout.class.php
+++ b/wpsc-includes/checkout.class.php
@@ -162,7 +162,7 @@ class wpsc_checkout {
 	 * wpsc_checkout method, gets the tax rate as a percentage, based on the selected country and region
 	 * @access public
 	 */
-	function wpsc_checkout( $checkout_set = 0 ) {
+	public function __construct( $checkout_set = 0 ) {
 		global $wpdb;
 		$this->checkout_items = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `" . WPSC_TABLE_CHECKOUT_FORMS . "` WHERE `active` = '1'  AND `checkout_set`= %s ORDER BY `checkout_order`;", $checkout_set ) );
 

--- a/wpsc-includes/coupons.class.php
+++ b/wpsc-includes/coupons.class.php
@@ -69,7 +69,7 @@ class wpsc_coupons {
 	 * @param string code (optional) the coupon code you would like to use.
 	 * @return bool True if coupon code exists, False otherwise.
 	 */
-	function wpsc_coupons( $code = '' ) {
+	public function __construct( $code = '' ) {
 	    global $wpdb;
 
 		if ( empty( $code ) ) {

--- a/wpsc-includes/purchaselogs.class.php
+++ b/wpsc-includes/purchaselogs.class.php
@@ -695,7 +695,7 @@ class wpsc_purchaselogs {
    var $end_timestamp;
 
 	/* Constructor function */
-	function wpsc_purchaselogs() {
+	public function __construct() {
 		$this->getall_formdata();
 		if ( !isset( $_GET['view_purchlogs_by'] ) && !isset( $_GET['purchlogs_searchbox'] ) ) {
 			$dates = $this->getdates();
@@ -1010,7 +1010,7 @@ class wpsc_purchaselogs_items {
    var $additional_fields = array();
 
 
-   function wpsc_purchaselogs_items( $id ) {
+   public function __construct( $id ) {
 	  $this->purchlogid = $id;
 	  $this->get_purchlog_details();
    }

--- a/wpsc-includes/shipping.helper.php
+++ b/wpsc-includes/shipping.helper.php
@@ -374,10 +374,10 @@ class ASHPackage {
      * The constructor for the ASHPackage class
      * Accepts an arguments array to fill out the class on initialization
      *
-     * @since 0.0.1
+     * @since 3.11.3
      * @param array $args
      */
-    function ASHPackage(array $args = array()){
+   public function __construct(array $args = array()){
         foreach($args as $key=>$value){
             $this->$key=$value;
         }
@@ -483,9 +483,9 @@ class ASHShipment{
     /**
      * Constructor for the ASHShipment class
      *
-     * @since 0.0.1
+     * @since 3.11.3
      */
-    function ASHShipment(){
+    public function __construct(){
     }
 
     /**
@@ -564,7 +564,7 @@ class ASH{
      * General constructor for ASH class
      *
      */
-    function ASH(){
+    public function _construct(){
     }
 
     /**

--- a/wpsc-includes/theming.class.php
+++ b/wpsc-includes/theming.class.php
@@ -37,7 +37,7 @@ class wpsc_theming {
 	 *
 	 * @return
 	 */
-	function wpsc_theming() {
+	public function __construct() {
 		check_admin_referer( 'wpsc_copy_themes' );
 
 		$this->active_wp_style   = trailingslashit( get_stylesheet_directory() );

--- a/wpsc-shipping/flatrate.php
+++ b/wpsc-shipping/flatrate.php
@@ -14,7 +14,7 @@ class flatrate {
 	 *
 	 * @return boolean Always returns true.
 	 */
-	function flatrate() {
+	public function __construct() {
 		$this->internal_name = "flatrate";
 		$this->name= __( "Flat Rate", 'wp-e-commerce' );
 		$this->is_external = false;

--- a/wpsc-shipping/tablerate.php
+++ b/wpsc-shipping/tablerate.php
@@ -15,7 +15,7 @@ class tablerate {
 	 *
 	 * @return boolean Always returns true.
 	 */
-	function tablerate() {
+	public function __construct() {
 		$this->internal_name = "tablerate";
 		$this->name = __( "Table Rate", 'wp-e-commerce' );
 		$this->is_external=false;

--- a/wpsc-shipping/ups_20.php
+++ b/wpsc-shipping/ups_20.php
@@ -18,7 +18,7 @@ class ash_ups {
 	public $drop_types = array();
 	public $cust_types = array();
 
-	function ash_ups () {
+	public function __construct() {
 		$this->internal_name = 'ups';
 		$this->name = _x( 'UPS', 'Shipping Module', 'wp-e-commerce' );
 		$this->is_external = true;

--- a/wpsc-shipping/usps_20.php
+++ b/wpsc-shipping/usps_20.php
@@ -70,7 +70,7 @@ class ash_usps {
 	 * Automatically loads services that are available into the class instance
 	 * @since 1.0
 	 */
-	function ash_usps() {
+	public function __construct() {
 		$this->_load_services();
 		return TRUE;
 	}


### PR DESCRIPTION
Fixes #2050, as far as I can tell. 

If anyone finds other classes that need updating let me know, and if I find any I'll update them. Also, see questions in [my first comment on #2050](https://github.com/wp-e-commerce/WP-e-Commerce/issues/2050#issuecomment-172625643).