### PR TITLE
Move permission check out of Coupon class, and into caller

### DIFF
--- a/wpsc-admin/display-coupons.php
+++ b/wpsc-admin/display-coupons.php
@@ -14,6 +14,10 @@ function wpsc_display_coupons_page() {
 
 			check_admin_referer( 'wpsc_coupon', 'wpsc-coupon-add' );
 
+			if ( ! function_exists( 'wpsc_is_store_admin' ) || ! wpsc_is_store_admin() ) {
+				wp_die( __( 'Permission denied', 'wpsc' ) );
+			}
+
 			$coupon_code   = $_POST['add_coupon_code'];
 			$discount      = (double)$_POST['add_discount'];
 			$discount_type = (int)$_POST['add_discount_type'];
@@ -60,6 +64,10 @@ function wpsc_display_coupons_page() {
 		if ( isset( $_POST['is_edit_coupon'] ) && ($_POST['is_edit_coupon'] == 'true') && !(isset( $_POST['delete_condition'] )) && !(isset( $_POST['submit_condition'] )) ) {
 
 			check_admin_referer( 'wpsc_coupon', 'wpsc-coupon-edit' );
+
+			if ( ! function_exists( 'wpsc_is_store_admin' ) || ! wpsc_is_store_admin() ) {
+				wp_die( __( 'Permission denied', 'wpsc' ) );
+			}
 
 			$rules     = isset( $_POST['rules'] ) ? $_POST['rules'] : array();
 			$new_rules = array();

--- a/wpsc-includes/coupon.class.php
+++ b/wpsc-includes/coupon.class.php
@@ -342,10 +342,6 @@ class WPSC_Coupon {
 
 		global $wpdb;
 
-		if ( ! function_exists( 'wpsc_is_store_admin' ) || ! wpsc_is_store_admin() ) {
-			return false;
-		}
-
 		do_action( 'wpsc_coupon_pre_save', $this );
 
 		$result = false;


### PR DESCRIPTION
Currently the WPSC_Coupon class cannot be used to programatically create coupons. The reason is that the save method contains this logic:

```php
if ( ! function_exists( 'wpsc_is_store_admin' ) || ! wpsc_is_store_admin() ) {
	return false;
}
```

Other code may want to create coupons programatically without the user being logged in with store admin privileges (In response to front end forms, cron jobs etc.). This is blocked by this code currently. The access check should be done outside of this class to enable it to be re-used. 

PR attached for discussion. Questions about this PR:

1. The used() method of the WPSC_Coupons class also calls save(), I'm not sure how this ever worked before?
2. Do we actually need the access checks I've introduced into display-coupons.php since access to that page is blocked anyway by a capability added when the page is registered
3. Do we need access checks anywhere else.

