### PR TITLE
Address php warning/error related to switching theme engines. Fixes #2084

### DIFF
--- a/wpsc-includes/wpsc-theme-engine-bootstrap.php
+++ b/wpsc-includes/wpsc-theme-engine-bootstrap.php
@@ -214,8 +214,9 @@ function _wpsc_maybe_activate_theme_engine_v2() {
 
 		update_option( 'wpsc_get_active_theme_engine', $new_theme_engine );
 
+		$location = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : home_url();
 		// Redirect ensures that both templates will not be loaded, fixing fatal errors, etc.
-		wp_redirect( esc_url_raw( remove_query_arg( 'blah' ) ) );
+		wp_redirect( esc_url_raw( $location ) );
 		exit;
 	}
 

--- a/wpsc-includes/wpsc-theme-engine-bootstrap.php
+++ b/wpsc-includes/wpsc-theme-engine-bootstrap.php
@@ -203,6 +203,9 @@ function _wpsc_maybe_activate_theme_engine_v2() {
 
 	if ( $old_theme_engine !== $new_theme_engine ) {
 
+		// _wpsc_action_flush_rewrite_rules lives here.
+		require_once( WPSC_FILE_PATH . '/wpsc-admin/init.php' );
+
 		do_action( 'wpsc_updated_theme_engine', $new_theme_engine, $old_theme_engine );
 
 		do_action( "wpsc_updated_theme_engine_from_{$old_theme_engine}_to_{$new_theme_engine}" );
@@ -210,6 +213,10 @@ function _wpsc_maybe_activate_theme_engine_v2() {
 		add_action( 'shutdown', '_wpsc_action_flush_rewrite_rules' );
 
 		update_option( 'wpsc_get_active_theme_engine', $new_theme_engine );
+
+		// Redirect ensures that both templates will not be loaded, fixing fatal errors, etc.
+		wp_redirect( esc_url_raw( remove_query_arg( 'blah' ) ) );
+		exit;
 	}
 
 	return $activate;

--- a/wpsc-includes/wpsc-theme-engine-bootstrap.php
+++ b/wpsc-includes/wpsc-theme-engine-bootstrap.php
@@ -216,7 +216,7 @@ function _wpsc_maybe_activate_theme_engine_v2() {
 
 		$location = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : home_url();
 		// Redirect ensures that both templates will not be loaded, fixing fatal errors, etc.
-		wp_redirect( esc_url_raw( $location ) );
+		wp_safe_redirect( esc_url_raw( $location ) );
 		exit;
 	}
 


### PR DESCRIPTION
Solves:

`PHP Warning:  call_user_func_array() expects parameter 1 to be a valid
callback, function '_wpsc_action_flush_rewrite_rules' not found or
invalid function name in
/srv/www/wpecommerce/htdocs/wp-includes/plugin.php on line 525`

`PHP Fatal error:  Cannot redeclare wpsc_is_checkout() (previously
declared in
/srv/www/wpecommerce/htdocs/wp-content/plugins/wp-e-commerce/wpsc-components/theme-engine-v2/helpers/conditional-tags.php:100)
in
/srv/www/wpecommerce/htdocs/wp-content/plugins/wp-e-commerce/wpsc-components/theme-engine-v1/helpers/template.php
on line 31`