### PR TITLE
Fixes debug notices related to 'sizes' not being set on attachment metadata

### DIFF
--- a/wpsc-components/theme-engine-v2/helpers/template-engine.php
+++ b/wpsc-components/theme-engine-v2/helpers/template-engine.php
@@ -478,7 +478,7 @@ function _wpsc_filter_generate_attachment_metadata( $metadata, $id ) {
 		$key = "wpsc_product_{$size}_thumbnail";
 
 		// if this size is not generated for this attachment, skip it
-		if ( ! array_key_exists( $key, $metadata['sizes'] ) ) {
+		if ( ! isset( $metadata['sizes'] ) || ! array_key_exists( $key, $metadata['sizes'] ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
The `'sizes'` parameter in the `$metadata` array passed through the
`'wp_generate_attachment_metadata'` filter is not guaranteed to be there, and
therefore can cause the following notices/warnings:

- PHP Notice:  Undefined index: sizes in
.../wp-e-commerce/wpsc-components/theme-engine-v2/helpers/template-engine.php
on line 481

- PHP Warning:  array_key_exists() expects parameter 2 to be array, null
given in
.../wp-e-commerce/wpsc-components/theme-engine-v2/helpers/template-engine.php
on line 481