### PR TITLE
Enable button_class param for form_actions when type is button.

### DIFF
--- a/wpsc-components/theme-engine-v2/helpers/form.php
+++ b/wpsc-components/theme-engine-v2/helpers/form.php
@@ -124,9 +124,9 @@ function wpsc_get_form_output( $args ) {
 	$defaults = apply_filters( 'wpsc_get_form_output_default_args', $defaults );
 
 	$r = wp_parse_args( $args, $defaults );
-	
+
 	$output = "<form id='{$r['id']}' method='{$r['method']}' action='{$r['action']}' class='{$r['class']}'>";
-	
+
 	foreach ( $r['fields'] as $field ) {
 		$output .= _wpsc_get_field_output( $field, $r );
 	}
@@ -429,18 +429,21 @@ function _wpsc_filter_control_hidden( $output, $field, $args ) {
 }
 
 function _wpsc_filter_control_button( $output, $field, $args ) {
-	extract( $field );
 	$class = $args['id'] . '-button wpsc-button';
 
 	if ( $field['primary'] ) {
 		$class .= ' wpsc-button-primary';
 	}
 
+	if ( isset( $field['button_class'] ) ) {
+		$class .= ' ' . $field['button_class'];
+	}
+
 	if ( ! isset( $field['icon'] ) ) {
 		$field['icon'] = '';
 	}
 
-	$output .= wpsc_form_button( $name, $title, array( 'class' => $class, 'icon' => $field['icon'] ), false );
+	$output .= wpsc_form_button( $field['name'], $field['title'], array( 'class' => $class, 'icon' => $field['icon'] ), false );
 
 	return $output;
 }

--- a/wpsc-components/theme-engine-v2/helpers/template-tags/form.php
+++ b/wpsc-components/theme-engine-v2/helpers/template-tags/form.php
@@ -57,13 +57,14 @@ function wpsc_get_add_to_cart_form_args( $id = null ) {
 	$args['form_actions'] = array(
 		// Add to Cart button
 		array(
-			'type' => 'button',
-			'primary' => true,
-			'icon'    => apply_filters(
+			'type'         => 'button',
+			'primary'      => true,
+			'button_class' => 'wpsc-add-to-cart',
+			'icon'         => apply_filters(
 				'wpsc_add_to_cart_button_icon',
 				array( 'shopping-cart', 'white' )
 			),
-			'title'   => apply_filters(
+			'title'        => apply_filters(
 				'wpsc_add_to_cart_button_title',
 				__( 'Add to Cart', 'wp-e-commerce' )
 			),
@@ -804,7 +805,7 @@ function wpsc_get_begin_checkout_button() {
 	$args = apply_filters(
 		'wpsc_begin_checkout_button_args',
 		array(
-			'class' => 'wpsc-button wpsc-button-primary',
+			'class' => 'wpsc-button wpsc-button-primary wpsc-begin-checkout',
 			'icon'  => $icon,
 		)
 	);


### PR DESCRIPTION
Since the normal class parameter is abandoned (because it contains
irrelevant field- classes), this allows custom classes for buttons to
still be passed.

Also adds semantic classes to add-to-cart and begin-checkout buttons