### PR TITLE
Add script enqueue que

### DIFF
--- a/wpsc-components/theme-engine-v2/classes/template-engine.php
+++ b/wpsc-components/theme-engine-v2/classes/template-engine.php
@@ -211,7 +211,7 @@ class WPSC_Template_Engine {
 	 *
 	 * @since 4.0
 	 * @param string $handle      Name of the core script to queue.
-	 * @param array  $script_data (Optional) data to send to wp_localize_script under the WPEC namespace.
+	 * @param array  $script_data (Optional) data to send to wp_localize_script under the WPSC namespace.
 	 */
 	public function register_queued_script( $handle, $script_data = array() ) {
 		$this->queued_scripts[ $handle ] = $script_data;

--- a/wpsc-components/theme-engine-v2/classes/template-engine.php
+++ b/wpsc-components/theme-engine-v2/classes/template-engine.php
@@ -52,6 +52,53 @@ class WPSC_Template_Engine {
 	private $view_wrapper_paths = array();
 
 	/**
+	 * Core scripts ready to be enqueued during the wp_enqueue_scripts hook.
+	 *
+	 * @since 4.0
+	 * @var array
+	 */
+	private $queued_scripts = array();
+
+	/**
+	 * Core scripts to register during wp_enqueue_scripts hook.
+	 *
+	 * @since 4.0
+	 * @var array
+	 */
+	private $core_scripts = array(
+		'wpsc-select-autocomplete' => array(
+			'path'         => 'js/jquery.select-to-autocomplete.js',
+			'dependencies' => array( 'jquery-ui-autocomplete' ),
+			'version'      => '1.0.5',
+		),
+		'wpsc-country-region' => array(
+			'path'         => 'js/country-region.js',
+			'dependencies' => array( 'wpsc-select-autocomplete', 'jquery' ),
+			'version'      => WPSC_VERSION,
+		),
+		'wpsc-copy-billing-info' => array(
+			'path'         => 'js/copy-billing-info.js',
+			'dependencies' => array( 'jquery' ),
+			'version'      => WPSC_VERSION,
+		),
+		'wpsc-shipping-price-simulator' => array(
+			'path'         => 'js/shipping-price-simulator.js',
+			'dependencies' => array( 'jquery' ),
+			'version'      => WPSC_VERSION,
+		),
+		'wpsc-checkout-payment' => array(
+			'path'         => 'js/checkout-payment.js',
+			'dependencies' => array( 'jquery' ),
+			'version'      => WPSC_VERSION,
+		),
+		'wpsc-cart-notifications' => array(
+			'path'         => 'js/cart-notifications.js',
+			'dependencies' => array( 'jquery' ),
+			'version'      => WPSC_VERSION,
+		),
+	);
+
+	/**
 	 * Constructor
 	 *
 	 * @since 4.0
@@ -116,6 +163,16 @@ class WPSC_Template_Engine {
 	}
 
 	/**
+	 * Get all the registered core scripts data.
+	 *
+	 * @since  4.0
+	 * @return array
+	 */
+	public function get_core_scripts_data() {
+		return $this->core_scripts;
+	}
+
+	/**
 	 * Register a path where template engine can look for a certain asset file
 	 *
 	 * @since 4.0
@@ -149,6 +206,16 @@ class WPSC_Template_Engine {
 		$this->register_thing( 'view_wrapper_paths', $path, $priority );
 	}
 
+	/**
+	 * Register a path where template engine can look for a certain view wraper
+	 *
+	 * @since 4.0
+	 * @param string $handle      Name of the core script to queue.
+	 * @param array  $script_data (Optional) data to send to wp_localize_script under the WPEC namespace.
+	 */
+	public function register_queued_script( $handle, $script_data = array() ) {
+		$this->queued_scripts[ $handle ] = $script_data;
+	}
 
 	/**
 	 * Deregister a path where template engine can look for a certain asset.
@@ -266,6 +333,16 @@ class WPSC_Template_Engine {
 	 */
 	public function get_view_wrapper_paths() {
 		return $this->get_paths( 'view_wrapper_paths' );
+	}
+
+	/**
+	 * Get all the registered queued scripts.
+	 *
+	 * @since  4.0
+	 * @return array
+	 */
+	public function get_queued_scripts() {
+		return $this->queued_scripts;
 	}
 
 	/**

--- a/wpsc-components/theme-engine-v2/helpers/js.php
+++ b/wpsc-components/theme-engine-v2/helpers/js.php
@@ -140,7 +140,9 @@ function wpsc_localize_script( $handle, $property_name, $data, $add_to_namespace
 	global $wp_scripts;
 
 	if ( $add_to_namespace ) {
-		$property_name = 'WPSC.' . $property_name;
+
+		// Make sure this variable does not break the WPSC namespace.
+		$property_name = 'WPSC.' . sanitize_html_class( substr( serialize( $property_name ), 0, 60 ) );
 	}
 
 	$result = wp_localize_script( $handle, $property_name, $data );

--- a/wpsc-components/theme-engine-v2/helpers/js.php
+++ b/wpsc-components/theme-engine-v2/helpers/js.php
@@ -142,7 +142,7 @@ function wpsc_localize_script( $handle, $property_name, $data, $add_to_namespace
 	if ( $add_to_namespace ) {
 
 		// Make sure this variable does not break the WPSC namespace.
-		$property_name = 'WPSC.' . sanitize_html_class( substr( serialize( $property_name ), 0, 60 ) );
+		$property_name = 'WPSC.' . sanitize_html_class( maybe_serialize( $property_name ) );
 	}
 
 	$result = wp_localize_script( $handle, $property_name, $data );

--- a/wpsc-components/theme-engine-v2/helpers/js.php
+++ b/wpsc-components/theme-engine-v2/helpers/js.php
@@ -3,36 +3,33 @@
 add_action( 'wp_enqueue_scripts', '_wpsc_te2_register_scripts', 1 );
 
 function _wpsc_te2_register_scripts() {
-	wp_register_script(
-		'wpsc-select-autocomplete',
-		wpsc_locate_asset_uri( 'js/jquery.select-to-autocomplete.js' ),
-		array( 'jquery-ui-autocomplete' ),
-		'1.0.5'
-	);
-	wp_register_script(
-		'wpsc-country-region',
-		wpsc_locate_asset_uri( 'js/country-region.js' ),
-		array( 'wpsc-select-autocomplete', 'jquery' ),
-		WPSC_VERSION
-	);
-	wp_register_script(
-		'wpsc-copy-billing-info',
-		wpsc_locate_asset_uri( 'js/copy-billing-info.js' ),
-		array( 'jquery' ),
-		WPSC_VERSION
-	);
-	wp_register_script(
-		'wpsc-shipping-price-simulator',
-		wpsc_locate_asset_uri( 'js/shipping-price-simulator.js' ),
-		array( 'jquery' ),
-		WPSC_VERSION
-	);
-	wp_register_script(
-		'wpsc-checkout-payment',
-		wpsc_locate_asset_uri( 'js/checkout-payment.js' ),
-		array( 'jquery' ),
-		WPSC_VERSION
-	);
+
+	$engine = WPSC_Template_Engine::get_instance();
+
+	$scripts = apply_filters( 'wpsc_registered_scripts', $engine->get_core_scripts_data() );
+
+	foreach ( $scripts as $handle => $script_data ) {
+		wp_register_script(
+			$handle,
+			wpsc_locate_asset_uri( $script_data['path'] ),
+			$script_data['dependencies'],
+			$script_data['version'],
+			1
+		);
+	}
+
+	$enqueued = false;
+
+	foreach ( $engine->get_queued_scripts() as $handle => $script_data ) {
+		$enqueued = true;
+
+		_wpsc_enqueue_and_localize_script( $handle, $script_data );
+	}
+
+	if ( $enqueued ) {
+		// Output our namespace.
+		?><script type='text/javascript'>/* <![CDATA[ */window.WPSC = window.WPSC || {};/* ]]> */</script><?php
+	}
 
 	do_action( 'wpsc_register_scripts' );
 	do_action( 'wpsc_enqueue_scripts' );
@@ -46,12 +43,120 @@ function _wpsc_enqueue_shipping_billing_scripts() {
 }
 
 function _wpsc_action_enqueue_shipping_billing_scripts() {
-	wp_enqueue_script( 'wpsc-country-region' );
-	wp_enqueue_script( 'wpsc-copy-billing-info' );
-
-	wp_localize_script( 'wpsc-copy-billing-info', 'wpsc_checkout_labels', array(
-		'billing_and_shipping' => apply_filters( 'wpsc_checkout_billing_header_label'     , __( '<h2>Billing &amp; Shipping Details</h2>', 'wp-e-commerce' ) ),
-		'shipping'             => apply_filters( 'wpsc_checkout_shipping_header_label'    , __( '<h2>Shipping Details</h2>', 'wp-e-commerce' ) ),
-		'billing'              => apply_filters( 'wpsc_checkout_billing_only_header_label', __( '<h2>Billing Details</h2>', 'wp-e-commerce' ) ),
+	wpsc_enqueue_script( 'wpsc-country-region' );
+	wpsc_enqueue_script( 'wpsc-copy-billing-info', array(
+		'property_name' => 'copyBilling',
+		'data' => array(
+			'strings' => array(
+				'billing_and_shipping' => apply_filters( 'wpsc_checkout_billing_header_label' , __( '<h2>Billing &amp; Shipping Details</h2>', 'wp-e-commerce' ) ),
+				'shipping'             => apply_filters( 'wpsc_checkout_shipping_header_label' , __( '<h2>Shipping Details</h2>', 'wp-e-commerce' ) ),
+				'billing'              => apply_filters( 'wpsc_checkout_billing_only_header_label', __( '<h2>Billing Details</h2>', 'wp-e-commerce' ) ),
+			),
+		),
 	) );
+}
+
+/**
+ * Enqueue a registered wpsc script (and optionally localize its JS data).
+ * If script cannot be enqueued yet, register the queued script for later enqueue.
+ *
+ * @see WPSC_Template_Engine::register_queued_script()
+ * @see wp_enqueue_script()
+ * @see wpsc_localize_script()
+ *
+ * @since 4.0
+ *
+ * @param string $handle      Name of the registered wpsc script.
+ * @param array  $script_data (Optional) data to send to wp_localize_script under the WPSC namespace.
+ */
+function wpsc_enqueue_script( $handle, $script_data = array() ) {
+	if ( ! did_action( 'wpsc_enqueue_scripts' ) ) {
+		WPSC_Template_Engine::get_instance()->register_queued_script( $handle, $script_data );
+	} else {
+		_wpsc_enqueue_and_localize_script( $handle, $script_data );
+	}
+}
+
+/**
+ * Enqueue a registered wpsc script (and optionally localize its JS data).
+ *
+ * @see wp_enqueue_script()
+ * @see wpsc_localize_script()
+ *
+ * @access private
+ *
+ * @since 4.0
+ *
+ * @param string $handle      Name of the registered wpsc script.
+ * @param array  $script_data (Optional) data to send to wp_localize_script under the WPSC namespace.
+ */
+function _wpsc_enqueue_and_localize_script( $handle, $script_data = array() ) {
+	wp_enqueue_script( $handle );
+
+	if ( ! empty( $script_data ) && isset( $script_data['property_name'], $script_data['data'] ) ) {
+
+		$add_to_namespace = ! isset( $script_data['add_to_namespace'] ) || $script_data['add_to_namespace'];
+
+		wpsc_localize_script(
+			$handle,
+			$script_data['property_name'],
+			$script_data['data'],
+			$add_to_namespace
+		);
+	}
+}
+
+/**
+ * Localize a script under the WPSC namespace.
+ *
+ * Works only if the script has already been registered or enqueued.
+ *
+ * Accepts an associative array $data and creates a JavaScript object:
+ *
+ *     window.WPSC.{$property_name} = {
+ *         key: value,
+ *         key: value,
+ *         ...
+ *     }
+ *
+ *
+ * @see wp_localize_script()
+ * @see WP_Dependencies::get_data()
+ * @see WP_Dependencies::add_data()
+ * @global WP_Scripts $wp_scripts The WP_Scripts object for printing scripts.
+ *
+ * @since 4.0
+ *
+ * @param string $handle          Script handle the data will be attached to.
+ * @param string $property_name   Name for the property applied to the global WPSC object.
+ *                                Passed directly, so it should be qualified JS variable.
+ *                                Example: '/[a-zA-Z0-9_]+/'.
+ * @param array $data             The data itself. The data can be either a single or multi-dimensional array.
+ * @param bool  $add_to_namespace Whether to add to the WPSC object, or default wp_localize_script output.
+ *
+ * @return bool True if the script was successfully localized, false otherwise.
+ */
+function wpsc_localize_script( $handle, $property_name, $data, $add_to_namespace = true ) {
+	global $wp_scripts;
+
+	if ( $add_to_namespace ) {
+		$property_name = 'WPSC.' . $property_name;
+	}
+
+	$result = wp_localize_script( $handle, $property_name, $data );
+
+	if ( $add_to_namespace ) {
+
+		$script = $wp_scripts->get_data( $handle, 'data' );
+
+		$script = str_replace(
+			"var {$property_name} = {",
+			"window.{$property_name} = window.{$property_name} || {",
+			$script
+		);
+
+		$result = $wp_scripts->add_data( $handle, 'data', $script );
+	}
+
+	return $result;
 }

--- a/wpsc-components/theme-engine-v2/helpers/js.php
+++ b/wpsc-components/theme-engine-v2/helpers/js.php
@@ -14,7 +14,7 @@ function _wpsc_te2_register_scripts() {
 			wpsc_locate_asset_uri( $script_data['path'] ),
 			$script_data['dependencies'],
 			$script_data['version'],
-			1
+			! isset( $script_data['in_footer'] ) || $script_data['in_footer']
 		);
 	}
 

--- a/wpsc-components/theme-engine-v2/helpers/template-engine.php
+++ b/wpsc-components/theme-engine-v2/helpers/template-engine.php
@@ -478,7 +478,7 @@ function _wpsc_filter_generate_attachment_metadata( $metadata, $id ) {
 		$key = "wpsc_product_{$size}_thumbnail";
 
 		// if this size is not generated for this attachment, skip it
-		if ( ! array_key_exists( $key, $metadata['sizes'] ) ) {
+		if ( ! isset( $metadata['sizes'] ) || ! array_key_exists( $key, $metadata['sizes'] ) ) {
 			continue;
 		}
 

--- a/wpsc-components/theme-engine-v2/theming/assets/js/copy-billing-info.js
+++ b/wpsc-components/theme-engine-v2/theming/assets/js/copy-billing-info.js
@@ -2,7 +2,9 @@
 
 	'use strict';
 
-	var event_copy = function(e) {
+	var strings = window.WPSC.copyBilling.strings;
+
+	var event_copy = function() {
 		var fields_to_copy = [
 			'firstname',
 			'lastname',
@@ -21,26 +23,28 @@
 			billing = $('#wpsc-checkout-field-billing' + field + '-control');
 			value = billing.val();
 			shipping.val(value);
-			if (field == 'country' || field == 'state') {
+			if ( 'country' === field || 'state' === field ) {
 				shipping.
 					siblings('input.ui-autocomplete-input').
 					val(shipping.find('option[value="' + value + '"]').text());
 
-				if (field == 'state')
+				if ( 'state' === field ) {
 					continue;
+				}
 
 				instance = shipping.data('wpsc_country_field');
 				instance.refresh_state_control({'real-value' : value});
 			}
 		}
-	},
-	set_visibility = function() {
+	};
+
+	var set_visibility = function() {
 
 		if ( $( 'input[name="wpsc_copy_billing_details"]' ).is( ':checked' ) ) {
-			$( '#wpsc-checkout-form-billing h2' ).html( wpsc_checkout_labels.billing_and_shipping );
+			$( '#wpsc-checkout-form-billing h2' ).html( strings.billing_and_shipping );
 			$( '#wpsc-checkout-form-shipping' ).addClass( 'ui-helper-hidden' );
 		} else {
-			$( '#wpsc-checkout-form-billing h2' ).html( wpsc_checkout_labels.billing );
+			$( '#wpsc-checkout-form-billing h2' ).html( strings.billing );
 			$( '#wpsc-checkout-form-shipping' ).removeClass( 'ui-helper-hidden' );
 		}
 	};


### PR DESCRIPTION
Update WPSC_Template_Engine to handle registering enqueued scripts.

Because of the output buffering, there are many cases where naked calls
to wp_enqueue_script will not work as it happens to early. This allows a
CRUD interface for dealing with those scripts and also allows us to
provide an interface for localizing variables within the WPSC namespace.
