### PR TITLE
Renamed: wpec none to wpsc none to match the accepting nonce

### DIFF
--- a/wpsc-admin/includes/display-items-functions.php
+++ b/wpsc-admin/includes/display-items-functions.php
@@ -930,7 +930,7 @@ function wpsc_product_gallery( $post ) {
 	$output .= '</p>';
 
 	// include a nonce for verification
-	$output .= wp_nonce_field( 'wpec_product_gallery_nonce', 'wpec_product_gallery_nonce', false, false );
+	$output .= wp_nonce_field( 'wpsc_product_gallery_nonce', 'wpsc_product_gallery_nonce', false, false );
 
 	// echo the gallery output
 	echo $output;


### PR DESCRIPTION
This wrong reference to the nonce, causes the wpsc_new_gallery_save hook to return premature (as the nonce will not validate), and thus, not save the correct order of the images.
