### PR TITLE
Moved Paypal Express checkout button to top of cart

### DIFF
--- a/wpsc-components/merchant-core-v3/gateways/paypal-digital-goods.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-digital-goods.php
@@ -84,13 +84,13 @@ class WPSC_Payment_Gateway_Paypal_Digital_Goods extends WPSC_Payment_Gateway_Pay
 			return;
 		}
 
-        if ( 'top' == $context ) {
+        if ( 'bottom' == $context ) {
             return;
         }
 
 		if ( _wpsc_get_current_controller_name() === 'cart' ) {
 			$url = $this->get_shortcut_url();
-			echo '<a id="pp-ecs-dg" href="'. esc_url ( $url ) .'"><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/checkout-logo-large.png" alt="' . __( 'Check out with PayPal', 'wp-e-commerce' ) . '" /></a>';
+			echo '<a class="express-checkout-button" id="pp-ecs-dg" href="'. esc_url ( $url ) .'"><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/checkout-logo-large.png" alt="' . __( 'Check out with PayPal', 'wp-e-commerce' ) . '" /></a>';
 		}
 	}
 

--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -57,13 +57,13 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 			return;
 		}
 
-		if ( 'top' == $context ) {
+		if ( 'bottom' == $context ) {
 			return;
 		}
 
 		if ( _wpsc_get_current_controller_name() === 'cart' ) {
 			$url = $this->get_shortcut_url();
-			echo '<a href="'. esc_url( $url ) .'"><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/checkout-logo-large.png" alt="' . __( 'Check out with PayPal', 'wp-e-commerce' ) . '" /></a>';
+			echo '<a class="express-checkout-button" href="'. esc_url( $url ) .'"><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/checkout-logo-large.png" alt="' . __( 'Check out with PayPal', 'wp-e-commerce' ) . '" /></a>';
 		}
 	}
 

--- a/wpsc-components/theme-engine-v2/theming/assets/css/wpsc-responsive.css
+++ b/wpsc-components/theme-engine-v2/theming/assets/css/wpsc-responsive.css
@@ -83,12 +83,10 @@ Shopping Cart
 .wpsc-cart-cell:last-of-type, .wpsc-cart-cell-header:last-of-type, .wpsc-cart-cell-header:last-of-type {
   margin-right: 0; }
 
-.express-checkout-button {
+.top .express-checkout-button, .top .wpsc-begin-checkout {
   display: inline-block;
   vertical-align: bottom; }
-
-.wpsc-begin-checkout {
-  display: inline-block;
+.top .wpsc-begin-checkout {
   margin-left: 20px; }
 
 /* Single Product Row */
@@ -232,6 +230,15 @@ Media Queries
     display: block;
     float: none;
     width: 100%; }
+
+  .top .wpsc-begin-checkout,
+  .top .express-checkout-button,
+  .top .wpsc-begin-checkout {
+    display: block;
+    text-align: left;
+    margin-left: 0; }
+  .top .express-checkout-button, .top .wpsc-begin-checkout {
+    margin-bottom: 20px; }
 
   .wpsc-cart-footer .wpsc-cart-actions-row {
     text-align: right;

--- a/wpsc-components/theme-engine-v2/theming/assets/css/wpsc-responsive.css
+++ b/wpsc-components/theme-engine-v2/theming/assets/css/wpsc-responsive.css
@@ -46,7 +46,6 @@ Variables
   .wpsc-list .wpsc-thumbnail-wrapper {
     display: inline-block; }
   .wpsc-list .wpsc-product-summary {
-<<<<<<< HEAD
     display: inline-block;
     float: right; }
 
@@ -57,8 +56,6 @@ Variables
   .wpsc-single .wpsc-thumbnail-wrapper {
     display: inline-block; }
   .wpsc-single .wpsc-product-summary {
-=======
->>>>>>> d29a63003f81940a56950508d8afb2480d329963
     display: inline-block;
     float: right; }
 
@@ -391,6 +388,9 @@ Media Queries
     display: block;
     float: none;
     width: 100%; }
+
+  .wpsc-controller .wpsc-shopping-cart .wpsc-form-actions {
+    text-align: left; }
 
   .top .wpsc-begin-checkout,
   .top .express-checkout-button,

--- a/wpsc-components/theme-engine-v2/theming/assets/css/wpsc-responsive.css
+++ b/wpsc-components/theme-engine-v2/theming/assets/css/wpsc-responsive.css
@@ -83,6 +83,14 @@ Shopping Cart
 .wpsc-cart-cell:last-of-type, .wpsc-cart-cell-header:last-of-type, .wpsc-cart-cell-header:last-of-type {
   margin-right: 0; }
 
+.express-checkout-button {
+  display: inline-block;
+  vertical-align: bottom; }
+
+.wpsc-begin-checkout {
+  display: inline-block;
+  margin-left: 20px; }
+
 /* Single Product Row */
 .wpsc-cart-cell.image, .image.wpsc-cart-cell-header {
   width: 20%; }

--- a/wpsc-components/theme-engine-v2/theming/assets/scss/partials/_media-queries.scss
+++ b/wpsc-components/theme-engine-v2/theming/assets/scss/partials/_media-queries.scss
@@ -65,6 +65,9 @@ Media Queries
 			width: $full-width;
 		}	
 	}
+	.wpsc-controller .wpsc-shopping-cart .wpsc-form-actions {
+		text-align: left;
+	}
 	.top {
 		.wpsc-begin-checkout,
 		.express-checkout-button {

--- a/wpsc-components/theme-engine-v2/theming/assets/scss/partials/_media-queries.scss
+++ b/wpsc-components/theme-engine-v2/theming/assets/scss/partials/_media-queries.scss
@@ -41,6 +41,17 @@ Media Queries
 			width: $full-width;
 		}	
 	}
+	.top {
+		.wpsc-begin-checkout,
+		.express-checkout-button {
+			display: block;
+			text-align: left;
+			margin-left: 0;
+		}	
+		.express-checkout-button {
+			margin-bottom: 20px;
+		}
+	}
 	.wpsc-cart-footer {
 		.wpsc-cart-actions-row {
 			text-align: right;

--- a/wpsc-components/theme-engine-v2/theming/assets/scss/partials/_shopping-cart.scss
+++ b/wpsc-components/theme-engine-v2/theming/assets/scss/partials/_shopping-cart.scss
@@ -28,6 +28,15 @@ Shopping Cart
 .wpsc-cart-cell:last-of-type, .wpsc-cart-cell-header:last-of-type {
     margin-right: 0;
 }
+.express-checkout-button {
+	display: inline-block;
+    vertical-align: bottom;
+}
+.wpsc-begin-checkout {
+    display: inline-block;
+    margin-left: 20px;
+}
+
 /* Single Product Row */
 .wpsc-cart-cell.image {
     width: $cart_image_width;

--- a/wpsc-components/theme-engine-v2/theming/assets/scss/partials/_shopping-cart.scss
+++ b/wpsc-components/theme-engine-v2/theming/assets/scss/partials/_shopping-cart.scss
@@ -28,13 +28,16 @@ Shopping Cart
 .wpsc-cart-cell:last-of-type, .wpsc-cart-cell-header:last-of-type {
     margin-right: 0;
 }
-.express-checkout-button {
-	display: inline-block;
-    vertical-align: bottom;
-}
-.wpsc-begin-checkout {
-    display: inline-block;
-    margin-left: 20px;
+
+.top {
+	.express-checkout-button {
+		display: inline-block;
+	    vertical-align: bottom;
+	}
+	.wpsc-begin-checkout {
+	    @extend .express-checkout-button;
+	    margin-left: 20px;
+	}
 }
 
 /* Single Product Row */


### PR DESCRIPTION
Moved the paypal express checkout button to top since the purpose of the button is to expedite checkout and scrolling down takes longer.  Also styled to be in same alignment as checkout button to provide consistency.