### PR TITLE
Product name filter in purchase log should pass the product ID as a parameter

### DIFF
--- a/wpsc-includes/purchaselogs.class.php
+++ b/wpsc-includes/purchaselogs.class.php
@@ -299,7 +299,7 @@ function wpsc_have_purchaselog_details() {
 
 function wpsc_purchaselog_details_name() {
    global $purchlogitem;
-   return esc_html( apply_filters( 'the_title', $purchlogitem->purchitem->name ) );
+   return esc_html( apply_filters( 'the_title', $purchlogitem->purchitem->name, $purchlogitem->purchitem->prodid ) );
 }
 
 function wpsc_purchaselog_details_id() {


### PR DESCRIPTION
See `the_title` filter documentation which passes a post ID: https://codex.wordpress.org/Plugin_API/Filter_Reference/the_title