### PR TITLE
Hide digital downloads if no sales

### DIFF
--- a/wpsc-components/theme-engine-v2/classes/digital-contents-table.php
+++ b/wpsc-components/theme-engine-v2/classes/digital-contents-table.php
@@ -44,6 +44,11 @@ class WPSC_Digital_Contents_Table extends WPSC_Table {
 
 		$downloadables = $wpdb->get_results( $sql );
 
+		if ( empty( $downloadables ) ) {
+			$this->digital_items = array();
+			return;
+		}
+		
 		$product_ids = wp_list_pluck( $downloadables, 'product_id' );
 		$product_ids = array_unique( array_map( 'absint', $product_ids ) );
 		$this->items = get_posts( array(


### PR DESCRIPTION
If user has no purchase do not show any downloads in the digital tab.
I'm not sure if the `$this->digital_items = array();` is needed but there is a check inside `column_contents` but it won't hurt setting it to empty

Should fix #2119