### PR TITLE
Express Checkout 3.0 Fix refund type

### DIFF
--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -1100,7 +1100,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 			'note'           => $reason,
 		);
 
-		if( $amount && $amount <= $log->get_remaining_refund() ) {
+		if( $amount && $amount < $log->get_remaining_refund() ) {
 			$options['refund_type'] = 'Partial';
 			$options['amount']      = $amount;
 		} else {


### PR DESCRIPTION
Fix the condition for refund_type to be considered partial when requested amount is lower than the remaining to be refunded