### PR TITLE
Edit shortcut buttons on the cart page for Express Checkout

### DIFF
--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -78,13 +78,10 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 			return;
 		}
 
-		if ( 'bottom' == $context ) {
-			return;
-		}
-
 		if ( _wpsc_get_current_controller_name() === 'cart' ) {
 			$url = $this->get_shortcut_url();
-			echo '<a class="express-checkout-button" href="'. esc_url( $url ) .'" id="express-checkout-cart-button"><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/checkout-logo-large.png" alt="' . __( 'Check out with PayPal', 'wp-e-commerce' ) . '" /></a>';
+			echo '<a class="express-checkout-button" href="'. esc_url( $url ) .'" id="express-checkout-cart-button"><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/checkout-logo-small.png" alt="' . __( 'Check out with PayPal', 'wp-e-commerce' ) . '" /></a>';
+			_e( '&mdash; or &mdash;', 'wp-e-commerce' );
 		}
 	}
 


### PR DESCRIPTION
Show buttons top and bottom, replace image with smaller one and also add spacer between button and regular go to checkout button