### PR TITLE
Remove esc_url in EC 3.0

### DIFF
--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -206,7 +206,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		);
 		$url = add_query_arg( $args, $url );
 
-		return esc_url( $url );
+		return $url;
 	}
 
 	/**


### PR DESCRIPTION
Remove usage of esc_url in the review order url creation