### PR TITLE
Change Express Checkout useraction param

### DIFF
--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -274,9 +274,12 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 
 		// Common Vars
 		$common = array(
-			'cmd'        => '_express-checkout',
-			'useraction' => 'commit',
+		    'cmd'        => '_express-checkout',
 		);
+
+		if ( ! wpsc_uses_shipping() ) {
+		   $common['useraction'] = 'commit';
+		}
 
 		if ( wp_is_mobile() ) {
 			$common['cmd'] = '_express-checkout-mobile';


### PR DESCRIPTION
If shipping exists for the cart 'useraction' parameter will not be set thus making the PayPal button text say "Continue" on the review order page instead of "Pay Now"