### PR TITLE
Adjust useraction parameter based on cart location

### DIFF
--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -277,7 +277,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		    'cmd'        => '_express-checkout',
 		);
 
-		if ( ! wpsc_uses_shipping() ) {
+		if ( ! wpsc_uses_shipping() || wpsc_is_checkout() ) {
 		   $common['useraction'] = 'commit';
 		}
 


### PR DESCRIPTION
If user redirects to PayPal from the /payment/ screen then the useraction will be commit since shipping if any has already been calculated.
If users uses the shortcut button and there is shipping then there is no useraction set since user has to return for shipping calculation