### PR TITLE
Use cart url instead of refferrer for add coupons

### DIFF
--- a/wpsc-components/theme-engine-v2/mvc/controllers/cart.php
+++ b/wpsc-components/theme-engine-v2/mvc/controllers/cart.php
@@ -227,9 +227,8 @@ class WPSC_Controller_Cart extends WPSC_Controller {
 			$this->message_collection->add( __( 'Coupon applied.', 'wp-e-commerce' ), 'success', 'main', 'flash' );
 		}
 
-		wp_safe_redirect( wp_get_referer() );
-		die;
-
+		wp_safe_redirect( wpsc_get_cart_url() );
+		exit;
 	}
 
 	public function clear() {


### PR DESCRIPTION
Just to be safe in case the wp_get_referer() returns false (just happened)