### PR TITLE
Don’t show shipping error on checkout if country not yet selected.

### DIFF
--- a/wpsc-components/theme-engine-v1/templates/wpsc-shopping_cart_page.php
+++ b/wpsc-components/theme-engine-v1/templates/wpsc-shopping_cart_page.php
@@ -147,7 +147,7 @@ endif;
                         <?php _e('Please provide a Zipcode and click Calculate in order to continue.', 'wp-e-commerce'); ?>
                      </td>
                   </tr>
-            <?php else: ?>
+            <?php elseif ( ! empty( wpsc_get_customer_meta( 'shippingcountry' ) ) ) : ?>
                <tr class='wpsc_update_location_error'>
                   <td colspan='5' class='shipping_error' >
                      <?php _e('Sorry, shipping quotes could not be calculated with the details provided. Please double check your shipping address details.', 'wp-e-commerce'); ?>


### PR DESCRIPTION
I'm not sure if this is the correct fix (but works for me) as I don't use any other shipping integrations which may affect this, **so please check and review...**

The issue is as a new visitors the site, with settings set for users not to have to register and using v1 theme engine.

When visiting the checkout for the first time, initially not shipping country is set and the following error is show:

> Sorry, online ordering is unavailable to this destination and/or weight. Please double check your destination details.

I think this error should not be shown on first visit to the page when a user hasn't selected a shipping option, only after you have selected a shipping option?