### PR TITLE
Log object registry

### DIFF
--- a/wpsc-components/merchant-core-v2/helpers/checkout.php
+++ b/wpsc-components/merchant-core-v2/helpers/checkout.php
@@ -56,7 +56,7 @@ function _wpsc_filter_merchant_v2_payment_method_form_fields( $fields ) {
 
 	if ( empty( $selected_value ) ) {
 		$current_purchase_log_id = wpsc_get_customer_meta( 'current_purchase_log_id' );
-		$purchase_log = new WPSC_Purchase_Log( $current_purchase_log_id );
+		$purchase_log = wpsc_get_order( $current_purchase_log_id );
 		$selected_value = $purchase_log->get( 'gateway' );
 	}
 

--- a/wpsc-components/merchant-core-v3/gateways/amazon-payments.php
+++ b/wpsc-components/merchant-core-v3/gateways/amazon-payments.php
@@ -980,7 +980,7 @@ class WPSC_Amazon_Payments_Order_Handler {
 	}
 
 	public function set_purchase_log( $id ) {
-		$this->log = new WPSC_Purchase_Log( $id );
+		$this->log = wpsc_get_order( $id );
 	}
 
 	/**

--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -342,7 +342,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		}
 
 		// Create a new Purchase Log entry
-		$purchase_log = new WPSC_Purchase_Log( $sessionid, 'sessionid' );
+		$purchase_log = wpsc_get_order( $sessionid, 'sessionid' );
 
 		if ( ! $purchase_log->exists() ) {
 			return null;

--- a/wpsc-components/merchant-core-v3/gateways/paypal-pro.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-pro.php
@@ -149,9 +149,9 @@ class WPSC_Payment_Gateway_Paypal_Pro extends WPSC_Payment_Gateway {
 
 		// Create a new Purchase Log entry
 		if ( $sessionid === 'sessionid' ) {
-			$purchase_log = new WPSC_Purchase_Log( $id, 'sessionid' );
+			$purchase_log = wpsc_get_order( $id, 'sessionid' );
 		} else {
-			$purchase_log = new WPSC_Purchase_Log( $id, 'id' );
+			$purchase_log = wpsc_get_order( $id, 'id' );
 		}
 
 		if ( ! $purchase_log->exists() ) {

--- a/wpsc-components/merchant-core-v3/gateways/worldpay.php
+++ b/wpsc-components/merchant-core-v3/gateways/worldpay.php
@@ -413,7 +413,7 @@ class WPSC_Payment_Gateway_WorldPay extends WPSC_Payment_Gateway {
 	public function type_of_goods( $log_id ) {
 		$digital = 0;
 
-		$log = new WPSC_Purchase_Log( $log_id );
+		$log = wpsc_get_order( $log_id );
 		$cart = $log->get_items();
 
 		foreach ( $cart as $cartitem ) {
@@ -460,7 +460,7 @@ class WPSC_WorldPay_Payments_Order_Handler {
 	}
 
 	public function set_purchase_log( $id ) {
-		$this->log = new WPSC_Purchase_Log( $id );
+		$this->log = wpsc_get_order( $id );
 	}
 
 	/**

--- a/wpsc-components/merchant-core-v3/helpers/checkout.php
+++ b/wpsc-components/merchant-core-v3/helpers/checkout.php
@@ -111,7 +111,7 @@ function _wpsc_filter_merchant_v3_payment_method_form_fields( $fields ) {
 
 	if ( empty( $selected_value ) ) {
 		$current_purchase_log_id = wpsc_get_customer_meta( 'current_purchase_log_id' );
-		$purchase_log            = new WPSC_Purchase_Log( $current_purchase_log_id );
+		$purchase_log            = wpsc_get_order( $current_purchase_log_id );
 		$selected_value          = $purchase_log->get( 'gateway' );
 	}
 

--- a/wpsc-components/theme-engine-v1/helpers/ajax.php
+++ b/wpsc-components/theme-engine-v1/helpers/ajax.php
@@ -735,7 +735,7 @@ function wpsc_submit_checkout( $collected_data = true ) {
 			'wpec_taxes_rate'  => $tax_percentage,
 		);
 
-		$purchase_log = new WPSC_Purchase_Log( $args );
+		$purchase_log = wpsc_get_order( $args );
 		$purchase_log->save();
 		$purchase_log_id = $purchase_log->get( 'id' );
 

--- a/wpsc-components/theme-engine-v1/templates/functions/wpsc-transaction_results_functions.php
+++ b/wpsc-components/theme-engine-v1/templates/functions/wpsc-transaction_results_functions.php
@@ -15,7 +15,7 @@ function transaction_results( $sessionid, $display_to_screen = true, $transactio
 	// pre-3.8.9 variable
 	$echo_to_screen = $display_to_screen;
 
-	$purchase_log_object = new WPSC_Purchase_Log( $sessionid, 'sessionid' );
+	$purchase_log_object = wpsc_get_order( $sessionid, 'sessionid' );
 
 	// compatibility with pre-3.8.9 templates where they use a global
 	// $purchase_log object which is simply just a database row

--- a/wpsc-components/theme-engine-v2/classes/cart-item-table-order.php
+++ b/wpsc-components/theme-engine-v2/classes/cart-item-table-order.php
@@ -13,7 +13,7 @@ class WPSC_Cart_Item_Table_Order extends WPSC_Cart_Item_Table {
 		$this->show_thumbnails = true;
 		$this->show_shipping   = true;
 
-		$this->log   = new WPSC_Purchase_Log( $id );
+		$this->log   = wpsc_get_order( $id );
 		$this->items = $this->get_items();
 	}
 

--- a/wpsc-components/theme-engine-v2/classes/shipping-calculator.php
+++ b/wpsc-components/theme-engine-v2/classes/shipping-calculator.php
@@ -14,7 +14,7 @@ final class WPSC_Shipping_Calculator {
 		}
 
 		if ( is_int( $purchase_log ) ) {
-			$purchase_log = new WPSC_Purchase_Log( $purchase_log );
+			$purchase_log = wpsc_get_order( $purchase_log );
 		}
 
 		$id = $purchase_log->get( 'id' );
@@ -76,7 +76,7 @@ final class WPSC_Shipping_Calculator {
 
 		// in case of integer argument, initialize the purchase log object
 		if ( ! is_object( $purchase_log ) ) {
-			$purchase_log = new WPSC_Purchase_Log( absint( $purchase_log ) );
+			$purchase_log = wpsc_get_order( absint( $purchase_log ) );
 		}
 
 		$this->purchase_log = $purchase_log;
@@ -171,7 +171,7 @@ final class WPSC_Shipping_Calculator {
 
 		$current_purchase_log_id = wpsc_get_customer_meta( 'current_purchase_log_id' );
 
-		$purchase_log = new WPSC_Purchase_Log( $current_purchase_log_id );
+		$purchase_log = wpsc_get_order( $current_purchase_log_id );
 		$module       = $purchase_log->get( 'shipping_method' );
 		$option       = $purchase_log->get( 'shipping_option' );
 

--- a/wpsc-components/theme-engine-v2/helpers/checkout-results.php
+++ b/wpsc-components/theme-engine-v2/helpers/checkout-results.php
@@ -15,7 +15,7 @@ function transaction_results( $sessionid, $display_to_screen = true, $transactio
 	// pre-3.8.9 variable
 	$echo_to_screen = $display_to_screen;
 
-	$purchase_log_object = new WPSC_Purchase_Log( $sessionid, 'sessionid' );
+	$purchase_log_object = wpsc_get_order( $sessionid, 'sessionid' );
 
 	// compatibility with pre-3.8.9 templates where they use a global
 	// $purchase_log object which is simply just a database row

--- a/wpsc-components/theme-engine-v2/mvc/controllers/checkout.php
+++ b/wpsc-components/theme-engine-v2/mvc/controllers/checkout.php
@@ -161,7 +161,7 @@ class WPSC_Controller_Checkout extends WPSC_Controller {
 
 		// Update the Purchase Log
 		$purchase_log_id = wpsc_get_customer_meta( 'current_purchase_log_id' );
-		$purchase_log    = new WPSC_Purchase_Log( $purchase_log_id );
+		$purchase_log    = wpsc_get_order( $purchase_log_id );
 		$purchase_log->set( 'base_shipping', $wpsc_cart->calculate_base_shipping() );
 		$purchase_log->set( 'totalprice', $wpsc_cart->calculate_total_price() );
 		$purchase_log->save();
@@ -241,14 +241,14 @@ class WPSC_Controller_Checkout extends WPSC_Controller {
 		$create = true;
 
 		if ( $purchase_log_id ) {
-			$purchase_log = new WPSC_Purchase_Log( $purchase_log_id );
+			$purchase_log = wpsc_get_order( $purchase_log_id );
 			$create       = ! $purchase_log->exists();
 		}
 
 		if ( $create ) {
 			wpsc_delete_customer_meta( 'current_purchase_log_id' );
 
-			$purchase_log = new WPSC_Purchase_Log();
+			$purchase_log = wpsc_get_order();
 
 			$purchase_log->set( array(
 				'user_ID'        => get_current_user_id(),
@@ -452,7 +452,7 @@ class WPSC_Controller_Checkout extends WPSC_Controller {
 		}
 
 		$purchase_log_id   = wpsc_get_customer_meta( 'current_purchase_log_id' );
-		$purchase_log      = new WPSC_Purchase_Log( $purchase_log_id );
+		$purchase_log      = wpsc_get_order( $purchase_log_id );
 		$submitted_gateway = $_POST['wpsc_payment_method'];
 
 		$purchase_log->set( array(

--- a/wpsc-components/theme-engine-v2/mvc/controllers/customer-account.php
+++ b/wpsc-components/theme-engine-v2/mvc/controllers/customer-account.php
@@ -98,7 +98,7 @@ class WPSC_Controller_Customer_Account extends WPSC_Controller {
 		$this->view    = 'customer-account-order';
 		$form_data_obj = new WPSC_Checkout_Form_Data( $id );
 		$this->form    = WPSC_Checkout_Form::get();
-		$this->log     = new WPSC_Purchase_Log( $id );
+		$this->log     = wpsc_get_order( $id );
 		$this->title   = sprintf(
 			__( 'View Order #%d', 'wp-e-commerce' ),
 			$id

--- a/wpsc-includes/checkout-form-data.class.php
+++ b/wpsc-includes/checkout-form-data.class.php
@@ -289,7 +289,7 @@ class WPSC_Checkout_Form_Data extends WPSC_Query_Base {
 	 */
 	public function save() {
 
-		$log    = new WPSC_Purchase_Log( $this->log_id );
+		$log    = wpsc_get_order( $this->log_id );
 		$form   = WPSC_Checkout_Form::get();
 		$fields = $form->get_fields();
 

--- a/wpsc-includes/google-analytics.class.php
+++ b/wpsc-includes/google-analytics.class.php
@@ -151,7 +151,7 @@ class WPSC_Google_Analytics {
 	}
 	public function add_pushes( $session_id ) {
 
-		$purchase    = new WPSC_Purchase_Log( $session_id, 'sessionid' );
+		$purchase    = wpsc_get_order( $session_id, 'sessionid' );
 		$purchase_id = $purchase->get( 'id' );
 
 		$data = new WPSC_Checkout_Form_Data( $purchase_id );

--- a/wpsc-includes/merchant.class.php
+++ b/wpsc-includes/merchant.class.php
@@ -278,7 +278,7 @@ class wpsc_merchant {
 	 * go to transaction results, if this changes and you extend this, your merchant module may go to the wrong place
 	 */
 	function go_to_transaction_results( $session_id ) {
-		$purchase_log = new WPSC_Purchase_Log( $this->purchase_id );
+		$purchase_log = wpsc_get_order( $this->purchase_id );
 
 		//Now to do actions once the payment has been attempted
 		switch ( $purchase_log->get( 'processed' ) ) {
@@ -334,7 +334,7 @@ class wpsc_merchant {
 	 */
 	function set_authcode( $authcode, $append = false ){
 
-		$log              = new WPSC_Purchase_Log( $this->purchase_id );
+		$log              = wpsc_get_order( $this->purchase_id );
 		$current_authcode = $log->get( 'authcode' );
 
 		if ( $append && ! empty( $current_authcode ) ) {

--- a/wpsc-includes/purchase-log.helpers.php
+++ b/wpsc-includes/purchase-log.helpers.php
@@ -11,7 +11,7 @@
  */
 function wpsc_get_order( $order_id, $by = 'id' ) {
 	$order = wpsc_is_order( $order_id );
-	return $order ? $order : new WPSC_Purchase_Log( $order_id, $by );
+	return $order ? $order : WPSC_Purchase_Log::get_instance( $order_id, $by );
 }
 
 /**

--- a/wpsc-includes/purchaselogs-items.class.php
+++ b/wpsc-includes/purchaselogs-items.class.php
@@ -23,7 +23,7 @@ class wpsc_purchaselogs_items {
 
 		$this->log = $purchase_log instanceof WPSC_Purchase_Log
 			? $purchase_log
-			: new WPSC_Purchase_Log( $this->purchlogid );
+			: wpsc_get_order( $this->purchlogid );
 
 		$this->get_purchlog_details();
 	}

--- a/wpsc-includes/purchaselogs.functions.php
+++ b/wpsc-includes/purchaselogs.functions.php
@@ -557,7 +557,7 @@ function wpsc_purchlog_edit_status( $purchlog_id = '', $purchlog_status = '' ) {
 		$purchlog_status = absint( $_POST['new_status'] );
 	}
 
-	$purchase_log = new WPSC_Purchase_Log( $purchlog_id );
+	$purchase_log = wpsc_get_order( $purchlog_id );
 
    // In the future when everyone is using the 2.0 merchant api,
    // we should use the merchant class to update the staus,

--- a/wpsc-merchants/paypal-standard.merchant.php
+++ b/wpsc-merchants/paypal-standard.merchant.php
@@ -137,7 +137,7 @@ class wpsc_merchant_paypal_standard extends wpsc_merchant {
 				'notify_url' => $notify_url,
 			);
 		}
-		
+
 		// Customer details
 		$paypal_vars += array(
 			'email'      => $this->cart_data['email_address'],
@@ -422,7 +422,7 @@ class wpsc_merchant_paypal_standard extends wpsc_merchant {
 	private function import_ipn_data() {
 		global $wpdb;
 
-		$purchase_log = new WPSC_Purchase_Log( $this->cart_data['session_id'], 'sessionid' );
+		$purchase_log = wpsc_get_order( $this->cart_data['session_id'], 'sessionid' );
 
 		if ( ! $purchase_log->exists() ) {
 			return;
@@ -582,7 +582,7 @@ class wpsc_merchant_paypal_standard extends wpsc_merchant {
 			$valid = false;
 		}
 
-		$purchase_log = new WPSC_Purchase_Log( $this->cart_data['session_id'], 'sessionid' );
+		$purchase_log = wpsc_get_order( $this->cart_data['session_id'], 'sessionid' );
 
 		if ( ! $purchase_log->exists() ) {
 			$valid = false;
@@ -932,7 +932,7 @@ function _wpsc_buy_now_transaction_results() {
 	if ( ! isset( $_REQUEST['sessionid'] ) )
 		return;
 
-	$purchase_log = new WPSC_Purchase_Log( $_REQUEST['sessionid'], 'sessionid' );
+	$purchase_log = wpsc_get_order( $_REQUEST['sessionid'], 'sessionid' );
 
 	if ( ! $purchase_log->exists() || $purchase_log->is_transaction_completed() )
 		return;

--- a/wpsc-shipping/library/shipwire_functions.php
+++ b/wpsc-shipping/library/shipwire_functions.php
@@ -338,7 +338,7 @@ class WPSC_Shipwire {
 	 */
 	public function shipwire_on_checkout( $log_id ) {
 
-		$log = new WPSC_Purchase_Log( $log_id );
+		$log = wpsc_get_order( $log_id );
 
 		if ( ! $log->is_transaction_completed() ) {
 			return false;

--- a/wpsc-theme/functions/wpsc-transaction_results_functions.php
+++ b/wpsc-theme/functions/wpsc-transaction_results_functions.php
@@ -15,7 +15,7 @@ function transaction_results( $sessionid, $display_to_screen = true, $transactio
 	// pre-3.8.9 variable
 	$echo_to_screen = $display_to_screen;
 
-	$purchase_log_object = new WPSC_Purchase_Log( $sessionid, 'sessionid' );
+	$purchase_log_object = wpsc_get_order( $sessionid, 'sessionid' );
 
 	// compatibility with pre-3.8.9 templates where they use a global
 	// $purchase_log object which is simply just a database row


### PR DESCRIPTION
This PR builds on top of https://github.com/wp-e-commerce/WP-e-Commerce/pull/2254.

This is a major functional overhaul, and should introduce some significant performance benefits, but may also introduce bugs and should not be merged lightly. This needs to be thoroughly tested, ideally in all scenarios where `wpsc_get_order()` is used.