### PR TITLE
Fix warning on PHP 7.1

### DIFF
--- a/wpsc-includes/cart.class.php
+++ b/wpsc-includes/cart.class.php
@@ -1055,7 +1055,7 @@ class WPSC_Cart {
 	 */
 	function calculate_per_item_shipping( $method = null ) {
 		global $wpsc_shipping_modules;
-		$total = '';
+		$total = 0.0;
 		if ( $method == null ) {
 			$method = $this->selected_shipping_method;
 		}


### PR DESCRIPTION
PHP 7.1 now throws warnings if you try to "do maths with non-numbers" (proper definitions here: http://php.net/manual/en/migration71.other-changes.php). 

This causes WP e-Commerce to throw a warning on PHP 7.1 when there is something in the cart:

> Warning: A non-numeric value encountered in /www/sites/wpec_stable/wp-content/plugins/wp-e-commerce/wpsc-includes/cart.class.php

This PR resolves that by initialising the per_item_shipping to float 0.0, rather than an empty string.