### PR TITLE
issue/2302 – Avoid a fatal when activating via wp-cli

### DIFF
--- a/wpsc-core/wpsc-functions.php
+++ b/wpsc-core/wpsc-functions.php
@@ -650,12 +650,14 @@ function wpsc_serialize_shopping_cart() {
 		$wpsc_cart->errors = array();
 	}
 
-	// need to prevent set_cookie from being called at this stage in case the user just logged out
-	// because by now, some output must have been printed out
-	$customer_id = wpsc_get_current_customer_id();
+	if ( function_exists( 'wpsc_get_current_customer_id' ) ) {
+		// Need to prevent set_cookie from being called at this stage in case the user
+		// just logged out because by now, some output must have been printed out.
+		$customer_id = wpsc_get_current_customer_id();
 
-	if ( $customer_id ) {
-		wpsc_update_customer_cart( $wpsc_cart, $customer_id );
+		if ( $customer_id ) {
+			wpsc_update_customer_cart( $wpsc_cart, $customer_id );
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Issue: #2302

Wraps calls to two wpsc functions inside `wpsc_serialize_shopping_cart()` to avoid a fatal error when activating the plugin via wp-cli.