### PR TITLE
3.12.2 - fix loading animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-e-commerce",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "private": true,
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-e-commerce",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "private": true,
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ If you're looking for general user support, please submit your support request o
 Development status
 -------------------------
 
-* The latest stable version is [3.12.0](http://wordpress.org/extend/plugins/wp-e-commerce).
+* The latest stable version is [3.12.1](http://wordpress.org/extend/plugins/wp-e-commerce).
 * Active development version: 4.0-dev (branch [master](https://github.com/wp-e-commerce/WP-e-Commerce))
 * [Roadmap for 4.0](https://github.com/wp-e-commerce/wp-e-commerce/wiki/Roadmap)
 * [4.0 tickets](https://github.com/wp-e-commerce/WP-e-Commerce/milestones/4.0)

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ If you're looking for general user support, please submit your support request o
 Development status
 -------------------------
 
-* The latest stable version is [3.12.1](http://wordpress.org/extend/plugins/wp-e-commerce).
+* The latest stable version is [3.12.2](http://wordpress.org/extend/plugins/wp-e-commerce).
 * Active development version: 4.0-dev (branch [master](https://github.com/wp-e-commerce/WP-e-Commerce))
 * [Roadmap for 4.0](https://github.com/wp-e-commerce/wp-e-commerce/wiki/Roadmap)
 * [4.0 tickets](https://github.com/wp-e-commerce/WP-e-Commerce/milestones/4.0)

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,7 @@ After upgrading from earlier versions look for link "Update Store". This will up
 = 3.12.1 [2017-2-17] =
 
 * New: Addition of PayPal Credit to PayPal Express Checkout.
+* Fix: Ensure WPEC works via WP-CLI.
 
 = 3.12.0 [2017-2-17] =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpecommerce.org
 Tags: e-commerce, digital downloads, wp-e-commerce, shop, cart, paypal, authorize, stock control, ecommerce, shipping, tax
 Requires at least: 4.5
 Tested up to: 4.7.2
-Stable tag: 3.12.0
+Stable tag: 3.12.1
 
 WP eCommerce is a free, powerful plugin that empowers you to sell anything online, quickly and easily.
 
@@ -35,6 +35,10 @@ Before updating please make a backup of your existing files and database. Just i
 After upgrading from earlier versions look for link "Update Store". This will update your database structure to work with new version.
 
 == Changelog ==
+
+= 3.12.1 [2017-2-17] =
+
+* New: Addition of PayPal Credit to PayPal Express Checkout.
 
 = 3.12.0 [2017-2-17] =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpecommerce.org
 Tags: e-commerce, digital downloads, wp-e-commerce, shop, cart, paypal, authorize, stock control, ecommerce, shipping, tax
 Requires at least: 4.5
 Tested up to: 4.7.2
-Stable tag: 3.12.1
+Stable tag: 3.12.2
 
 WP eCommerce is a free, powerful plugin that empowers you to sell anything online, quickly and easily.
 
@@ -36,7 +36,11 @@ After upgrading from earlier versions look for link "Update Store". This will up
 
 == Changelog ==
 
-= 3.12.1 [2017-2-17] =
+= 3.12.2 [2017-3-25] =
+
+* Enhancement: Default PayPal Credit to On, and ensure it is functional for our 1.0 theme engine.
+
+= 3.12.1 [2017-3-24] =
 
 * New: Addition of PayPal Credit to PayPal Express Checkout.
 * Fix: Ensure WPEC works via WP-CLI.

--- a/wp-shopping-cart.php
+++ b/wp-shopping-cart.php
@@ -3,7 +3,7 @@
   * Plugin Name: WP eCommerce
   * Plugin URI: http://wpecommerce.org/
   * Description: A plugin that provides a WordPress Shopping Cart. See also: <a href="http://wpecommerce.org" target="_blank">WPeCommerce.org</a> | <a href="https://wordpress.org/support/plugin/wp-e-commerce/" target="_blank">Support Forum</a> | <a href="http://docs.wpecommerce.org/" target="_blank">Documentation</a>
-  * Version: 3.12.1
+  * Version: 3.12.2
   * Author: WP eCommerce
   * Author URI: http://wpecommerce.org/
   * Text Domain: wp-e-commerce

--- a/wp-shopping-cart.php
+++ b/wp-shopping-cart.php
@@ -3,7 +3,7 @@
   * Plugin Name: WP eCommerce
   * Plugin URI: http://wpecommerce.org/
   * Description: A plugin that provides a WordPress Shopping Cart. See also: <a href="http://wpecommerce.org" target="_blank">WPeCommerce.org</a> | <a href="https://wordpress.org/support/plugin/wp-e-commerce/" target="_blank">Support Forum</a> | <a href="http://docs.wpecommerce.org/" target="_blank">Documentation</a>
-  * Version: 3.12.0
+  * Version: 3.12.1
   * Author: WP eCommerce
   * Author URI: http://wpecommerce.org/
   * Text Domain: wp-e-commerce

--- a/wpsc-components/fancy-notifications/fancy-notifications.php
+++ b/wpsc-components/fancy-notifications/fancy-notifications.php
@@ -4,11 +4,7 @@
  * WP eCommerce Fancy Notifications
  */
 
-add_action( 'wp_enqueue_scripts', array( 'WPSC_Fancy_Notifications', 'enqueue_styles' ) );
-add_action( 'wp_enqueue_scripts', array( 'WPSC_Fancy_Notifications', 'enqueue_scripts' ) );
-add_action( 'wpsc_add_to_cart_button_form_begin', array( 'WPSC_Fancy_Notifications', 'add_fancy_notifications' ) );
-add_action( 'wpsc_theme_footer', array( 'WPSC_Fancy_Notifications', 'fancy_notifications' ) );
-add_filter( 'wpsc_add_to_cart_json_response', array( 'WPSC_Fancy_Notifications', 'wpsc_add_to_cart_json_response' ) );
+add_action( 'plugins_loaded', array( 'WPSC_Fancy_Notifications', 'setup_hooks' ) );
 
 /**
  * WP eCommerce Fancy Notifications Class
@@ -16,6 +12,23 @@ add_filter( 'wpsc_add_to_cart_json_response', array( 'WPSC_Fancy_Notifications',
  * @since  4.0
  */
 class WPSC_Fancy_Notifications {
+
+	/**
+	 * Setup Hooks
+	 */
+	public static function setup_hooks() {
+
+		if ( self::is_active() ) {
+
+			add_action( 'wp_enqueue_scripts', array( get_class(), 'enqueue_styles' ) );
+			add_action( 'wp_enqueue_scripts', array( get_class(), 'enqueue_scripts' ) );
+			add_action( 'wpsc_add_to_cart_button_form_begin', array( get_class(), 'add_fancy_notifications' ) );
+			add_action( 'wpsc_theme_footer', array( get_class(), 'fancy_notifications' ) );
+			add_filter( 'wpsc_add_to_cart_json_response', array( get_class(), 'wpsc_add_to_cart_json_response' ) );
+
+		}
+
+	}
 
 	/**
 	 * Fancy Notifications
@@ -125,6 +138,17 @@ class WPSC_Fancy_Notifications {
 	public static function enqueue_scripts() {
 
 		wp_enqueue_script( 'wpsc-fancy-notifications', self::plugin_url() . '/js/fancy-notifications.js', array( 'jquery' ), '1.0' );
+
+	}
+
+	/**
+	 * Is Active?
+	 *
+	 * @return  boolean
+	 */
+	public static function is_active() {
+
+		return get_option( 'fancy_notifications' ) == 1;
 
 	}
 

--- a/wpsc-components/merchant-core-v3/gateways/paypal-digital-goods.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-digital-goods.php
@@ -119,10 +119,10 @@ class WPSC_Payment_Gateway_Paypal_Digital_Goods extends WPSC_Payment_Gateway_Pay
      *
      * @return void
      */
-	public function get_shortcut_url() {
+	public function get_shortcut_url( $callback = 'shortcut_process' ) {
 		$location = add_query_arg( array(
 			'payment_gateway'          => 'paypal-digital-goods',
-			'payment_gateway_callback' => 'shortcut_process',
+			'payment_gateway_callback' => $callback,
 		), home_url( 'index.php' ) );
 
 		return apply_filters( 'wpsc_paypal_digital_goods_shortcut_url', $location );

--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -54,12 +54,22 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 			if ( (bool) $this->setting->get( 'incontext' ) ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'incontext_load_scripts' ) );
 			}
-			
+
 			// PayPal Credit Button
 			if ( (bool) $this->setting->get( 'credit' ) ) {
+				add_action( 'wpsc_gateway_v2_inside_gateway_label', array( $this, 'add_credit_button_tev1' ) );
 				add_action( 'wpsc_cart_item_table_form_actions_left', array( $this, 'add_credit_button' ), 1, 2 );
 			}
+
 		}
+	}
+
+	public function add_credit_button_tev1( $gateway ) {
+		if ( 'paypal-express-checkout' !== $gateway ) { return; }
+
+		$url = $this->get_shortcut_url( 'credit_process' );
+		echo '<em class="paypal-express-credit-separator">' . __( '&mdash; or &mdash;', 'wp-e-commerce' ) . '</em>';
+		echo '<a class="express-checkout-credit-button" href="'. esc_url( $url ) .'" id="express-checkout-cart-button"><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/ppcredit-logo-small.png" alt="' . __( 'PayPal Credit', 'wp-e-commerce' ) . '" /></a>';
 	}
 
 	public function incontext_load_scripts() {
@@ -113,7 +123,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 			echo '<em class="paypal-express-credit-separator">' . __( '&mdash; or &mdash;', 'wp-e-commerce' ) . '</em>';
 		}
 	}
-	
+
 	/**
 	 * Return the ExpressCheckout Shortcut redirection URL
 	 *
@@ -237,7 +247,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 			'sessionid'      => $sessionid,
 		) );
 
-		if ( wpsc_is_tax_included() ) {
+		if ( wpsc_tax_isincluded() ) {
 			$tax            = $wpsc_cart->calculate_total_tax();
 			$tax_percentage = $wpsc_cart->tax_percentage;
 		} else {
@@ -272,7 +282,8 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		// Save an empty Form
 		$form   = WPSC_Checkout_Form::get();
 		$fields = $form->get_fields();
-		WPSC_Checkout_Form_Data::save_form( $purchase_log, $fields );
+
+		WPSC_Checkout_Form_Data::save_form( $purchase_log, $fields, array(), false );
 
 		// Return Customer to Review Order Page if there is Shipping
 		add_filter( 'wpsc_paypal_express_checkout_transact_url', array( &$this, 'review_order_url' ) );
@@ -526,7 +537,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		}
 
 		// Save details to the Forms Table
-		WPSC_Checkout_Form_Data::save_form( $this->purchase_log, $fields );
+		WPSC_Checkout_Form_Data::save_form( $this->purchase_log, $fields, array(), false );
 	}
 
 	/**
@@ -1004,8 +1015,8 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		<label for="wpsc-paypal-express-cart-border"><?php _e( 'Enable PayPal Credit', 'wp-e-commerce' ); ?></label>
 	</td>
 	<td>
-		<label><input <?php checked( $this->setting->get( 'credit', '0' ) ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="1" /> <?php _e( 'Yes', 'wp-e-commerce' ); ?></label>&nbsp;&nbsp;&nbsp;
-		<label><input <?php checked( (bool) $this->setting->get( 'credit', '0' ), false ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="0" /> <?php _e( 'No', 'wp-e-commerce' ); ?></label>
+		<label><input <?php checked( $this->setting->get( 'credit', '1' ) ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="1" /> <?php _e( 'Yes', 'wp-e-commerce' ); ?></label>&nbsp;&nbsp;&nbsp;
+		<label><input <?php checked( (bool) $this->setting->get( 'credit', '1' ), false ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="0" /> <?php _e( 'No', 'wp-e-commerce' ); ?></label>
 	</td>
 </tr>
 <!-- Currency Conversion -->

--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -42,15 +42,22 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 				'cart_border'      => $this->setting->get( 'cart_border' ),
 				'incontext'        => (bool) $this->setting->get( 'incontext', '1' ),
 				'shortcut'         => (bool) $this->setting->get( 'shortcut' , '1' ),
+				'credit'           => (bool) $this->setting->get( 'credit' , '0' ),
 			) );
 
 			// Express Checkout Button
 			if ( (bool) $this->setting->get( 'shortcut' ) ) {
 				add_action( 'wpsc_cart_item_table_form_actions_left', array( $this, 'add_ecs_button' ), 2, 2 );
 			}
+
 			// Incontext Checkout Scripts
 			if ( (bool) $this->setting->get( 'incontext' ) ) {
 				add_action( 'wp_enqueue_scripts', array( $this, 'incontext_load_scripts' ) );
+			}
+			
+			// PayPal Credit Button
+			if ( (bool) $this->setting->get( 'credit' ) ) {
+				add_action( 'wpsc_cart_item_table_form_actions_left', array( $this, 'add_credit_button' ), 1, 2 );
 			}
 		}
 	}
@@ -90,14 +97,33 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 	}
 
 	/**
-	 * Return the ExpressCheckout Shortcut redirection URL
+	 * Insert the Credit Shortcut Button
 	 *
 	 * @return void
 	 */
-	public function get_shortcut_url() {
+	public function add_credit_button( $cart_table, $context ) {
+
+		if ( wpsc_is_gateway_active( 'paypal-digital-goods' ) || ! wpsc_is_gateway_active( 'paypal-express-checkout' ) ) {
+			return;
+		}
+
+		if ( _wpsc_get_current_controller_name() === 'cart' ) {
+			$url = $this->get_shortcut_url( 'credit_process' );
+			echo '<a class="express-checkout-credit-button" href="'. esc_url( $url ) .'" id="express-checkout-cart-button-' . $context . '"><img src="https://www.paypalobjects.com/webstatic/en_US/i/buttons/ppcredit-logo-large.png" alt="' . __( 'PayPal Credit', 'wp-e-commerce' ) . '" /></a>';
+			echo '<em class="paypal-express-credit-separator">' . __( '&mdash; or &mdash;', 'wp-e-commerce' ) . '</em>';
+		}
+	}
+	
+	/**
+	 * Return the ExpressCheckout Shortcut redirection URL
+	 *
+	 * @param string $callback
+	 * @return void
+	 */
+	public function get_shortcut_url( $callback = 'shortcut_process' ) {
 		$location = add_query_arg( array(
 			'payment_gateway'          => 'paypal-express-checkout',
-			'payment_gateway_callback' => 'shortcut_process',
+			'payment_gateway_callback' => $callback,
 		), home_url( 'index.php' ) );
 
 		return apply_filters( 'wpsc_paypal_express_checkout_shortcut_url', $location );
@@ -112,6 +138,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		if ( ! isset( $_GET['payment_gateway'] ) ) {
 			return;
 		}
+
 		$payment_gateway = $_GET['payment_gateway'];
 
 		global $wpsc_cart;
@@ -136,6 +163,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 			$tax            = 0;
 			$tax_percentage = 0;
 		}
+
 		$purchase_log->set( array(
 			'wpec_taxes_total' => $tax,
 			'wpec_taxes_rate'  => $tax_percentage,
@@ -182,6 +210,87 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		return $sessionid;
 	}
 
+	/**
+	 * Credit Shortcut Callback
+	 *
+	 * @return int
+	 */
+	public function callback_credit_process() {
+		if ( ! isset( $_GET['payment_gateway'] ) ) {
+			return;
+		}
+
+		$payment_gateway = $_GET['payment_gateway'];
+
+		global $wpsc_cart;
+		//	Create a new PurchaseLog Object
+		$purchase_log = new WPSC_Purchase_Log();
+
+		// Create a Sessionid
+		$sessionid = ( mt_rand( 100, 999 ) . time() );
+		wpsc_update_customer_meta( 'checkout_session_id', $sessionid );
+		$purchase_log->set( array(
+			'user_ID'        => get_current_user_id(),
+			'date'           => time(),
+			'plugin_version' => WPSC_VERSION,
+			'statusno'       => '0',
+			'sessionid'      => $sessionid,
+		) );
+
+		if ( wpsc_is_tax_included() ) {
+			$tax            = $wpsc_cart->calculate_total_tax();
+			$tax_percentage = $wpsc_cart->tax_percentage;
+		} else {
+			$tax            = 0;
+			$tax_percentage = 0;
+		}
+
+		$purchase_log->set( array(
+			'wpec_taxes_total' => $tax,
+			'wpec_taxes_rate'  => $tax_percentage,
+		) );
+
+		// Save the purchase_log object to generate it's id
+		$purchase_log->save();
+		$purchase_log_id = $purchase_log->get( 'id' );
+
+		$wpsc_cart->log_id = $purchase_log_id;
+		wpsc_update_customer_meta( 'current_purchase_log_id', $purchase_log_id );
+
+		$purchase_log->set( array(
+			'gateway'       => $payment_gateway,
+			'base_shipping' => $wpsc_cart->calculate_base_shipping(),
+			'totalprice'    => $wpsc_cart->calculate_total_price(),
+		) );
+
+		$purchase_log->save();
+
+		$wpsc_cart->empty_db( $purchase_log_id );
+		$wpsc_cart->save_to_db( $purchase_log_id );
+		$wpsc_cart->submit_stock_claims( $purchase_log_id );
+
+		// Save an empty Form
+		$form   = WPSC_Checkout_Form::get();
+		$fields = $form->get_fields();
+		WPSC_Checkout_Form_Data::save_form( $purchase_log, $fields );
+
+		// Return Customer to Review Order Page if there is Shipping
+		add_filter( 'wpsc_paypal_express_checkout_transact_url', array( &$this, 'review_order_url' ) );
+		add_filter( 'wpsc_paypal_express_checkout_return_url', array( &$this, 'review_order_callback' ) );
+
+		// Set a Temporary Option for EC Shortcut
+		wpsc_update_customer_meta( 'esc-' . $sessionid, true );
+
+		// Apply Checkout Actions
+		do_action( 'wpsc_submit_checkout', array(
+			'purchase_log_id' => $purchase_log_id,
+			'our_user_id'     => get_current_user_id(),
+		) );
+		do_action( 'wpsc_submit_checkout_gateway', $payment_gateway, $purchase_log );
+
+		return $sessionid;
+	}
+	
 	/**
 	 * Return Customer to Review Order Page if there are Shipping Costs.
 	 *
@@ -884,7 +993,21 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		<label><input <?php checked( (bool) $this->setting->get( 'incontext' ), false ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'incontext' ) ); ?>" value="0" /> <?php _e( 'No', 'wp-e-commerce' ); ?></label>
 	</td>
 </tr>
-
+<!-- PayPal Credit Shortcut -->
+<tr>
+	<td colspan="2">
+		<h4><?php _e( 'PayPal Credit Support', 'wp-e-commerce' ); ?></h4>
+	</td>
+</tr>
+<tr>
+	<td>
+		<label for="wpsc-paypal-express-cart-border"><?php _e( 'Enable PayPal Credit', 'wp-e-commerce' ); ?></label>
+	</td>
+	<td>
+		<label><input <?php checked( $this->setting->get( 'credit', '1' ) ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="1" /> <?php _e( 'Yes', 'wp-e-commerce' ); ?></label>&nbsp;&nbsp;&nbsp;
+		<label><input <?php checked( (bool) $this->setting->get( 'credit', '1' ), false ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="0" /> <?php _e( 'No', 'wp-e-commerce' ); ?></label>
+	</td>
+</tr>
 <!-- Currency Conversion -->
 <?php if ( ! $this->is_currency_supported() ) : ?>
 <tr>
@@ -997,6 +1120,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 	 * @since 3.9.0
 	 */
 	public function process() {
+
 		$total = $this->convert( $this->purchase_log->get( 'totalprice' ) );
 		$options = array(
 			'return_url'       => $this->get_return_url(),
@@ -1012,6 +1136,14 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 			$options['notify_url'] = $this->get_notify_url();
 		}
 
+		// Check if its a Credit transaction and pass required params.
+		if ( isset( $_GET['payment_gateway_callback'] ) && $_GET['payment_gateway_callback'] == 'credit_process' ) {
+			$options += array(
+				'solution_type'       => 'SOLE',
+				'user_funding_source' => 'Finance',
+			);
+		}
+		
 		// SetExpressCheckout
 		$response = $this->gateway->setup_purchase( $options );
 

--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -42,7 +42,7 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 				'cart_border'      => $this->setting->get( 'cart_border' ),
 				'incontext'        => (bool) $this->setting->get( 'incontext', '1' ),
 				'shortcut'         => (bool) $this->setting->get( 'shortcut' , '1' ),
-				'credit'           => (bool) $this->setting->get( 'credit' , '0' ),
+				'credit'           => (bool) $this->setting->get( 'credit' , '1' ),
 			) );
 
 			// Express Checkout Button

--- a/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/paypal-express-checkout.php
@@ -1004,8 +1004,8 @@ class WPSC_Payment_Gateway_Paypal_Express_Checkout extends WPSC_Payment_Gateway 
 		<label for="wpsc-paypal-express-cart-border"><?php _e( 'Enable PayPal Credit', 'wp-e-commerce' ); ?></label>
 	</td>
 	<td>
-		<label><input <?php checked( $this->setting->get( 'credit', '1' ) ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="1" /> <?php _e( 'Yes', 'wp-e-commerce' ); ?></label>&nbsp;&nbsp;&nbsp;
-		<label><input <?php checked( (bool) $this->setting->get( 'credit', '1' ), false ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="0" /> <?php _e( 'No', 'wp-e-commerce' ); ?></label>
+		<label><input <?php checked( $this->setting->get( 'credit', '0' ) ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="1" /> <?php _e( 'Yes', 'wp-e-commerce' ); ?></label>&nbsp;&nbsp;&nbsp;
+		<label><input <?php checked( (bool) $this->setting->get( 'credit', '0' ), false ); ?> type="radio" name="<?php echo esc_attr( $this->setting->get_field_name( 'credit' ) ); ?>" value="0" /> <?php _e( 'No', 'wp-e-commerce' ); ?></label>
 	</td>
 </tr>
 <!-- Currency Conversion -->

--- a/wpsc-components/merchant-core-v3/gateways/php-merchant/gateways/paypal-express-checkout.php
+++ b/wpsc-components/merchant-core-v3/gateways/php-merchant/gateways/paypal-express-checkout.php
@@ -193,6 +193,7 @@ class PHP_Merchant_Paypal_Express_Checkout extends PHP_Merchant_Paypal {
 			'MSGSUBID'	   => 'message_id',
 			'INVOICEID'	   => 'invoice',
 			'NOTE'         => 'note',
+			'USERSELECTEDFUNDINGSOURCE' => 'user_funding_source',
 		) );
 
 		// Cart Customization Fields
@@ -243,7 +244,6 @@ class PHP_Merchant_Paypal_Express_Checkout extends PHP_Merchant_Paypal {
 		$this->options = array_merge( $this->options, $options );
 		$this->requires( array( 'amount', 'return_url', 'cancel_url' ) );
 		$request = $this->build_checkout_request( $action, $options );
-
 		$response_str = $this->commit( 'SetExpressCheckout', $request );
 		return new PHP_Merchant_Paypal_Express_Checkout_Response( $response_str );
 	}

--- a/wpsc-core/wpsc-constants.php
+++ b/wpsc-core/wpsc-constants.php
@@ -55,7 +55,7 @@ function wpsc_core_constants() {
 
 	// Define Plugin version
 	if ( ! defined( 'WPSC_VERSION' ) ) {
-		define( 'WPSC_VERSION'            , '3.12.0' );
+		define( 'WPSC_VERSION'            , '3.12.1' );
 	}
 
 	if ( ! defined( 'WPSC_MINOR_VERSION' ) ) {
@@ -63,7 +63,7 @@ function wpsc_core_constants() {
 	}
 
 	if ( ! defined( 'WPSC_PRESENTABLE_VERSION' ) ) {
-		define( 'WPSC_PRESENTABLE_VERSION', '3.12.0' );
+		define( 'WPSC_PRESENTABLE_VERSION', '3.12.1' );
 	}
 
 	// Define a salt to use when we hash, WPSC_SALT may be defined for us in our config file, so check first

--- a/wpsc-core/wpsc-constants.php
+++ b/wpsc-core/wpsc-constants.php
@@ -55,7 +55,7 @@ function wpsc_core_constants() {
 
 	// Define Plugin version
 	if ( ! defined( 'WPSC_VERSION' ) ) {
-		define( 'WPSC_VERSION'            , '3.12.1' );
+		define( 'WPSC_VERSION'            , '3.12.2' );
 	}
 
 	if ( ! defined( 'WPSC_MINOR_VERSION' ) ) {
@@ -63,7 +63,7 @@ function wpsc_core_constants() {
 	}
 
 	if ( ! defined( 'WPSC_PRESENTABLE_VERSION' ) ) {
-		define( 'WPSC_PRESENTABLE_VERSION', '3.12.1' );
+		define( 'WPSC_PRESENTABLE_VERSION', '3.12.2' );
 	}
 
 	// Define a salt to use when we hash, WPSC_SALT may be defined for us in our config file, so check first

--- a/wpsc-core/wpsc-functions.php
+++ b/wpsc-core/wpsc-functions.php
@@ -644,12 +644,14 @@ function wpsc_serialize_shopping_cart() {
 		$wpsc_cart->errors = array();
 	}
 
-	// need to prevent set_cookie from being called at this stage in case the user just logged out
-	// because by now, some output must have been printed out
-	$customer_id = wpsc_get_current_customer_id();
+	if ( function_exists( 'wpsc_get_current_customer_id' ) ) {
+		// Need to prevent set_cookie from being called at this stage in case the user
+		// just logged out because by now, some output must have been printed out.
+		$customer_id = wpsc_get_current_customer_id();
 
-	if ( $customer_id ) {
-		wpsc_update_customer_cart( $wpsc_cart, $customer_id );
+		if ( $customer_id ) {
+			wpsc_update_customer_cart( $wpsc_cart, $customer_id );
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Fix for issue #2336:

In Theme Engine v1 `WPEC_Fancy_Notifications` JS component, the 'add to basket' loading animation is hidden even when fancy notifications is not active in admin settings.

This PR only adds the Fancy Notifications JS if the Presentation Options is selected in the admin.

This PR is only tested with Theme Engine v1.

Future-wise I'm not sure in TE2 wether we should still be loading the JS to despatch add to basket events for Fancy Notifications, just removing the listeners?

Having said that, there is a lot of traction at the moment on the WP Trac ticket for adding JavaScript actions and filters to core. Once something like that makes it into core it would make more sense to build the "add to basket" event using that framework so it is hackable via JS. https://core.trac.wordpress.org/ticket/21170