### PR TITLE
Sync cart model when the quantity is updated.

### DIFF
--- a/wpsc-components/theme-engine-v2/theming/assets/js/cart-notifications.js
+++ b/wpsc-components/theme-engine-v2/theming/assets/js/cart-notifications.js
@@ -579,6 +579,7 @@ module.exports = function (args, $id, log) {
 
 				// Update quantity.
 				model.set('quantity', qty);
+				model.sync('update', model);
 
 				this.setTotal();
 			} else {


### PR DESCRIPTION
Possible fix for #2342.

Calls model.sync() after updating the quantity of an item in the cart.
This isn't needed when calling collection.create() because it happens automatically.

Possible issues: Nothing's being passed as the 3rd parameter to the sync() method,
(the third param should be an ojbect of options). I'm hoping that Backbone will use
sane defaults.

See http://backbonejs.org/#Model-sync for more on the Sync method.