### PR TITLE
Remove server param from shipwire active check

### DIFF
--- a/wpsc-shipping/library/shipwire_functions.php
+++ b/wpsc-shipping/library/shipwire_functions.php
@@ -92,7 +92,7 @@ class WPSC_Shipwire {
 	 * @return boolean
 	 */
 	public static function is_active() {
-		return ( (bool) get_option( 'shipwire' ) && function_exists( 'simplexml_load_string' ) ) || isset( $_POST['server'] );
+		return (bool) get_option( 'shipwire' ) && function_exists( 'simplexml_load_string' );
 	}
 
 	/**


### PR DESCRIPTION
Possible fix for shipping methods disabling themselves on their own out of thin air