### PR TITLE
Allow retrieval of log via transactid

### DIFF
--- a/wpsc-includes/purchase-log.class.php
+++ b/wpsc-includes/purchase-log.class.php
@@ -555,7 +555,7 @@ class WPSC_Purchase_Log extends WPSC_Query_Base {
 
 		global $wpdb;
 
-		if ( ! in_array( $col, array( 'id', 'sessionid' ) ) ) {
+		if ( ! in_array( $col, array( 'id', 'sessionid', 'transactid' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
I don't know why we did not allowed it before but it "might" be helpful in cases of recurring payments when you don't have access to the id, sessionid but you know the original transactid

This simple changes lets it work BUT i see in the case of id and sessionid there is some caching done in this file so if it needs for transactid too let me know.